### PR TITLE
add more correctness to isValidSignature

### DIFF
--- a/contracts/libraries/ECDSA.sol
+++ b/contracts/libraries/ECDSA.sol
@@ -133,9 +133,8 @@ library ECDSA {
             mstore(add(ptr, 0x24), 0x40)
             mstore(add(ptr, 0x44), signature.length)
             calldatacopy(add(ptr, 0x64), signature.offset, signature.length)
-            mstore(0, 0)
             if staticcall(gas(), signer, ptr, add(0x64, signature.length), 0, 0x20) {
-                success := eq(selector, mload(0))
+                success := and(eq(selector, mload(0)), eq(returndatasize(), 0x20))
             }
         }
     }
@@ -153,9 +152,8 @@ library ECDSA {
             mstore(add(ptr, 0x64), r)
             mstore(add(ptr, 0x84), s)
             mstore8(add(ptr, 0xa4), v)
-            mstore(0, 0)
             if staticcall(gas(), signer, ptr, 0xa5, 0, 0x20) {
-                success := eq(selector, mload(0))
+                success := and(eq(selector, mload(0)), eq(returndatasize(), 0x20))
             }
         }
     }
@@ -174,9 +172,8 @@ library ECDSA {
             mstore(add(ptr, 0x44), 64)
             mstore(add(ptr, 0x64), r)
             mstore(add(ptr, 0x84), vs)
-            mstore(0, 0)
             if staticcall(gas(), signer, ptr, 0xa5, 0, 0x20) {
-                success := eq(selector, mload(0))
+                success := and(eq(selector, mload(0)), eq(returndatasize(), 0x20))
             }
         }
     }
@@ -196,9 +193,8 @@ library ECDSA {
             mstore(add(ptr, 0x64), r)
             mstore(add(ptr, 0x84), shr(1, shl(1, vs)))
             mstore8(add(ptr, 0xa4), add(27, shr(255, vs)))
-            mstore(0, 0)
             if staticcall(gas(), signer, ptr, 0xa5, 0, 0x20) {
-                success := eq(selector, mload(0))
+                success := and(eq(selector, mload(0)), eq(returndatasize(), 0x20))
             }
         }
     }


### PR DESCRIPTION
At the cost of 2 extra runtime gas we get output size validation check. By spec the function should return abi-encoded 4-byte selector which is 32 bytes of data.