### PR TITLE
Fix main entry point index.js path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "main": "dist/src/src/index.js",
   "types": "dist/src/src/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@1inch/solidity-utils",
   "version": "2.1.2",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/src/src/index.js",
+  "types": "dist/src/src/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/1inch/solidity-utils.git"


### PR DESCRIPTION
When installing and using solidity-utils lib the actual path to main entry index.js is dist/src/src/index.js rather than main entry point path dist/src/index.js.