### PR TITLE
Improve package.json scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - run: yarn typechain
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      - run: yarn build
       - run: yarn publish

--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,11 @@ cache
 node_modules
 coverage
 coverage.json
-build
 dist
+typechain-types
 .coverage_contracts
 .coverage_artifacts
 .env
 .idea
-typechain-types
 .DS_Store
 *.log
-mochaOutput.json

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
   },
   "license": "MIT",
   "scripts": {
-    "prebuild": "rimraf ./dist && cti src -b",
-    "build": "tsc -p tsconfig.publish.json",
-    "postbuild": "echo done",
-    "prepublish": "yarn build",
+    "clean": "rimraf artifacts cache coverage contracts/hardhat-dependency-compiler dist typechain-types",
+    "build": "yarn typechain && cti src -b && tsc -p tsconfig.publish.json",
+    "prepack": "yarn clean && yarn build",
     "coverage": "hardhat coverage",
     "format": "yarn format-ts && yarn format-sol",
     "format-ts": "prettier '**/*.ts' --write",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "repository": {


### PR DESCRIPTION
Investigated `package.json` scripts lifecycles:
- npm: https://docs.npmjs.com/cli/v9/using-npm/scripts#npm-pack  
- yarn: https://yarnpkg.com/advanced/lifecycle-scripts  Gtht

Decided the following:
- Use `prepack` for `clean` and `build`
- Use `build` for `typechain` and TS compilation
- Use `clean` for cleaning Solidity and JS related artifacts