### PR TITLE
[SC-846] Extract deploy helper implementations to solidity-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository contains frequently used smart contracts, libraries and interfac
 |utils|`fixSignature(signature)`|patchs ganache's signature to geth's version|
 |utils|`signMessage(signer, messageHex) `|signs `messageHex` with `signer` and patchs ganache's signature to geth's version|
 |utils|`countInstructions(txHash, instruction)`|counts amount of `instruction` in transaction with `txHash` hash|
+|utils|`deployAndGetContract(contractName, constructorArgs, deployments, deployer, deploymentName, skipVerify, skipIfAlreadyDeployed, gasPrice, maxPriorityFeePerGas, maxFeePerGas, log, waitConfirmations)`|deploys contract `contractName` as `deploymentName` if not `skipIfAlreadyDeployed` with `constructorArgs` from `deployer` using `hardhat-deploy` `deployments` with additional gas options `gasPrice`, `maxPriorityFeePerGas` and `maxFeePerGas` and outputs results to the console if `log`. Tries to verify it after `waitConfirmations` on Etherscan if not `skipVerify`.|
 |profileEVM|`profileEVM(txHash, instruction, optionalTraceFile)`|the same as the `countInstructions()` with option of writing all trace to `optionalTraceFile`|
 |profileEVM|`gasspectEVM(txHash, options, optionalTraceFile)`|returns all used operations in `txHash` transaction with `options` and their costs with option of writing all trace to `optionalTraceFile`|
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import '@nomiclabs/hardhat-ethers';
 import '@nomicfoundation/hardhat-chai-matchers';
 import 'hardhat-gas-reporter';
 import 'hardhat-tracer';
+import 'hardhat-deploy';
 require('solidity-coverage'); // require because no TS typings available
 import dotenv from 'dotenv';
 import { HardhatUserConfig } from 'hardhat/config';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,6 +4,7 @@ import '@nomicfoundation/hardhat-chai-matchers';
 import 'hardhat-gas-reporter';
 import 'hardhat-tracer';
 import 'hardhat-deploy';
+import '@nomicfoundation/hardhat-verify';
 require('solidity-coverage'); // require because no TS typings available
 import dotenv from 'dotenv';
 import { HardhatUserConfig } from 'hardhat/config';

--- a/hardhat.networks.ts
+++ b/hardhat.networks.ts
@@ -3,7 +3,11 @@ import { NetworksUserConfig } from 'hardhat/types';
 
 dotenv.config();
 
-const networks: NetworksUserConfig = {};
+const networks: NetworksUserConfig = {
+    hardhat: {
+        saveDeployments: false,
+    },
+};
 
 function register(name: string, chainId: number, url?: string, privateKey?: string) {
     if (url && privateKey) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "2.2.28",
+  "version": "2.3.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "1.0.6",
-    "@nomicfoundation/hardhat-verify": "^1.0.1",
+    "@nomicfoundation/hardhat-verify": "1.0.1",
     "@typechain/ethers-v5": "10.2.0",
     "@typechain/hardhat": "6.1.5",
     "@types/chai": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "1.0.6",
+    "@nomicfoundation/hardhat-verify": "^1.0.1",
     "@typechain/ethers-v5": "10.2.0",
     "@typechain/hardhat": "6.1.5",
     "@types/chai": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-standard": "5.0.0",
     "ethereumjs-wallet": "1.0.2",
     "hardhat": "2.13.0",
+    "hardhat-deploy": "0.11.30",
     "hardhat-gas-reporter": "1.0.9",
     "hardhat-tracer": "2.1.2",
     "prettier": "2.8.7",

--- a/src/prelude.ts
+++ b/src/prelude.ts
@@ -12,6 +12,7 @@ export const constants = {
     MIN_INT256: -(2n ** 255n),
     MAX_UINT128: 2n ** 128n - 1n,
     MAX_UINT32: 2n ** 32n - 1n,
+    DEV_CHAINS: ['hardhat', 'localhost'] as string[],
 } as const;
 
 // utils

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,10 +4,11 @@ import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { providers, Wallet, Contract, Bytes, ContractTransaction, BigNumberish, BigNumber } from 'ethers';
 import { Deployment, DeployOptions, DeployResult } from 'hardhat-deploy/types';
 
-const _delay = (ms: number ) =>
+const _delay = function (ms: number ) {
     new Promise((resolve) => {
         setTimeout(resolve, ms);
     });
+};
 
 const _getContract = async (contractName: string, contractAddress: string): Promise<Contract> => {
     const contractFactory = await ethers.getContractFactory(contractName);
@@ -16,6 +17,7 @@ const _getContract = async (contractName: string, contractAddress: string): Prom
 
 interface DeployContractOptions {
     contractName: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructorArgs?: any[];
     deployments: {
         deploy: (name: string, options: DeployOptions) => Promise<DeployResult>;
@@ -29,6 +31,7 @@ interface DeployContractOptions {
     maxPriorityFeePerGas?: BigNumber;
     maxFeePerGas?: BigNumber;
     log?: boolean;
+    waitConfirmations?: number;
 }
 
 export async function deployAndGetContract({
@@ -43,6 +46,7 @@ export async function deployAndGetContract({
     maxPriorityFeePerGas,
     maxFeePerGas,
     log = true,
+    waitConfirmations = constants.DEV_CHAINS.includes(hre.network.name) ? 1: 6,
 }: DeployContractOptions): Promise<Contract> {
     /**
      * Deploys contract and tries to verify it on Etherscan if requested.
@@ -61,7 +65,7 @@ export async function deployAndGetContract({
         maxPriorityFeePerGas,
         maxFeePerGas,
         log,
-        waitConfirmations: constants.DEV_CHAINS.includes(hre.network.name) ? 1: 6,
+        waitConfirmations,
     };
     const deployResult = await deploy(deploymentName, deployOptions);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,11 +10,6 @@ const _delay = function (ms: number) {
     });
 };
 
-const _getContract = async (contractName: string, contractAddress: string): Promise<Contract> => {
-    const contractFactory = await ethers.getContractFactory(contractName);
-    return contractFactory.attach(contractAddress);
-};
-
 interface DeployContractOptions {
     contractName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,7 +69,7 @@ export async function deployAndGetContract({
     } else {
         console.log('Skipping verification');
     }
-    return _getContract(contractName, deployResult.address);
+    return await ethers.getContractAt(contractName, deployResult.address);
 }
 
 export async function timeIncreaseTo(seconds: number | string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,12 +4,6 @@ import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { providers, Wallet, Contract, Bytes, ContractTransaction, BigNumberish, BigNumber } from 'ethers';
 import { DeployOptions, DeployResult } from 'hardhat-deploy/types';
 
-const _delay = function (ms: number) {
-    new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-};
-
 interface DeployContractOptions {
     contractName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -74,7 +68,7 @@ export async function deployAndGetContract({
 
 export async function timeIncreaseTo(seconds: number | string) {
     const delay = 1000 - new Date().getMilliseconds();
-    await _delay(delay);
+    await new Promise((resolve) => setTimeout(resolve, delay));
     await time.increaseTo(seconds);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,172 @@
 import { constants } from './prelude';
-import { ethers } from 'hardhat';
+import hre, { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
-import { providers, Wallet, Contract, Bytes, ContractTransaction, BigNumberish } from 'ethers';
+import { providers, Wallet, Contract, Bytes, ContractTransaction, BigNumberish, BigNumber } from 'ethers';
+import { Deployment, DeployOptions, DeployResult } from 'hardhat-deploy/types';
+
+const _delay = (ms: number ) =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+const _tryRun = async (f: () => Promise<any>, n = 10) => {
+    const delayMs = 2000;
+    if (typeof f !== 'function') {
+        throw Error('f is not a function');
+    }
+
+    for (let i = 0; ; i++) {
+        try {
+            return await f();
+        } catch (error) {
+            console.error(error);
+            await _delay(delayMs);
+            if (i > n) {
+                throw new Error(`Couldn't verify deploy in ${n} runs`);
+            }
+        }
+    }
+};
+
+const _getContract = async (contractName: string, contractAddress: string): Promise<Contract> => {
+    const contractFactory = await ethers.getContractFactory(contractName);
+    return contractFactory.attach(contractAddress);
+};
+
+interface DeployContractOptions {
+    contractName: string;
+    constructorArgs: any[];
+    deployments: {
+        deploy: (name: string, options: DeployOptions) => Promise<DeployResult>;
+        getOrNull: (name: string) => Promise<Deployment | null>
+    },
+    deployer: string;
+    deploymentName?: string;
+    skipVerify?: boolean;
+    skipIfAlreadyDeployed?: boolean;
+    gasPrice?: BigNumber;
+    maxPriorityFeePerGas?: BigNumber;
+    maxFeePerGas?: BigNumber;
+}
+
+export async function deployUnverified({
+    contractName,
+    constructorArgs,
+    deployments,
+    deployer,
+    deploymentName = contractName,
+    skipIfAlreadyDeployed = true,
+    gasPrice,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+}: DeployContractOptions): Promise<DeployResult | Deployment> {
+    /**
+     * Deploys a contract using hardhat-deploy plugin.
+     * @remarks
+     * This function will skip deployment if there is a deployment with the same name and `skipIfAlreadyDeployed` is true.
+     * Thus, even if the contract bytecode changes, the contract will not be redeployed.
+     */
+    const { deploy, getOrNull } = deployments;
+
+    const existingContract = await getOrNull(deploymentName);
+    if (existingContract && skipIfAlreadyDeployed) {
+        console.log(`Skipping deploy for existing contract ${contractName} (${deploymentName}) at address: ${existingContract.address}`);
+        return existingContract;
+    }
+
+    const deployOptions: DeployOptions = {
+        args: constructorArgs,
+        from: deployer,
+        contract: contractName,
+        skipIfAlreadyDeployed,
+        gasPrice,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+    };
+
+    const contract = await deploy(deploymentName, deployOptions);
+
+    console.log(`${deploymentName} deployed to: ${contract.address}`);
+    return contract;
+}
+
+export async function deployAndVerify({
+    contractName,
+    constructorArgs,
+    deployments,
+    deployer,
+    deploymentName = contractName,
+    skipIfAlreadyDeployed = true,
+    gasPrice,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+}: DeployContractOptions): Promise<DeployResult | Deployment> {
+    /**
+     * Deploys contract and tries to verify it on Etherscan.
+     * @remarks
+     * If the contract is deployed on a dev chain, verification is skipped.
+     */
+    const deployResult = await deployUnverified({
+        contractName,
+        constructorArgs,
+        deployments,
+        deployer,
+        deploymentName,
+        skipIfAlreadyDeployed,
+        gasPrice,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+    });
+
+    if (!constants.DEV_CHAINS.includes(hre.network.name)) {
+        await _delay(2000);
+        await _tryRun(() =>
+            hre.run('verify:verify', {
+                address: deployResult.address,
+                constructorArguments: constructorArgs,
+            }),
+        );
+    } else {
+        console.log('Skipping verification');
+    }
+
+    return deployResult;
+}
+
+export async function deployAndGetContract({
+    contractName,
+    constructorArgs,
+    deployments,
+    deployer,
+    deploymentName = contractName,
+    skipVerify = false,
+    skipIfAlreadyDeployed = true,
+    gasPrice,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+}: DeployContractOptions): Promise<Contract> {
+    /**
+     * Deploys contract and tries to verify it on Etherscan if requested.
+     * @returns Deployed contract instance
+     */
+    const deployOptions: DeployContractOptions = {
+        contractName,
+        constructorArgs,
+        deployments,
+        deployer,
+        deploymentName,
+        skipIfAlreadyDeployed,
+        gasPrice,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+    };
+    const deployResult = await (skipVerify ? deployUnverified(deployOptions) : deployAndVerify(deployOptions));
+    return _getContract(contractName, deployResult.address);
+}
 
 export async function timeIncreaseTo(seconds: number | string) {
     const delay = 1000 - new Date().getMilliseconds();
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    await _delay(delay);
     await time.increaseTo(seconds);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,9 @@ import { constants } from './prelude';
 import hre, { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
 import { providers, Wallet, Contract, Bytes, ContractTransaction, BigNumberish, BigNumber } from 'ethers';
-import { Deployment, DeployOptions, DeployResult } from 'hardhat-deploy/types';
+import { DeployOptions, DeployResult } from 'hardhat-deploy/types';
 
-const _delay = function (ms: number ) {
+const _delay = function (ms: number) {
     new Promise((resolve) => {
         setTimeout(resolve, ms);
     });
@@ -19,10 +19,7 @@ interface DeployContractOptions {
     contractName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructorArgs?: any[];
-    deployments: {
-        deploy: (name: string, options: DeployOptions) => Promise<DeployResult>;
-        getOrNull: (name: string) => Promise<Deployment | null>
-    },
+    deployments: {deploy: (name: string, options: DeployOptions) => Promise<DeployResult>},
     deployer: string;
     deploymentName?: string;
     skipVerify?: boolean;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { expect, ether, time, constants } from '../src/prelude';
-import { timeIncreaseTo, fixSignature, signMessage, trackReceivedTokenAndTx, countInstructions, deployContract } from '../src/utils';
-import hre from 'hardhat';
+import { timeIncreaseTo, fixSignature, signMessage, trackReceivedTokenAndTx, countInstructions, deployContract, deployAndGetContract } from '../src/utils';
+import hre, { deployments } from 'hardhat';
 const { ethers } = hre;
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
@@ -180,6 +180,23 @@ describe('utils', function () {
             const weth = await deployContract('WETH');
             expect(weth.address).to.be.not.eq(constants.ZERO_ADDRESS);
             expect(await weth.name()).to.be.eq('Wrapped Ether');
+        });
+    });
+
+    // TODO: fix the problem when plugin saves deployment on hardhat network in test env
+    describe('deployAndGetContract', function () {
+        it('should deploy new contract instance', async function () {
+            const tokenName = 'SomeToken';
+            const token = await deployAndGetContract({
+                contractName: 'TokenMock',
+                constructorArgs: [tokenName, 'STM'],
+                deployments,
+                deployer: signer1.address,
+                skipIfAlreadyDeployed: false,
+                skipVerify: true,
+            });
+            expect(token.address).to.be.not.eq(constants.ZERO_ADDRESS);
+            expect(await token.name()).to.be.eq(tokenName);
         });
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -183,10 +183,10 @@ describe('utils', function () {
         });
     });
 
-    // TODO: fix the problem when plugin saves deployment on hardhat network in test env
     describe('deployAndGetContract', function () {
         it('should deploy new contract instance', async function () {
             const tokenName = 'SomeToken';
+            // If hardhat-deploy `deploy` function logs need to be displayed, add HARDHAT_DEPLOY_LOG = 'true' to the .env file
             const token = await deployAndGetContract({
                 contractName: 'TokenMock',
                 constructorArgs: [tokenName, 'STM'],
@@ -197,6 +197,6 @@ describe('utils', function () {
             });
             expect(token.address).to.be.not.eq(constants.ZERO_ADDRESS);
             expect(await token.name()).to.be.eq(tokenName);
-        });
+        }); //.timeout(200000);  If this test needs to be run on a test chain, the timeout should be increased
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,7 +136,7 @@
     "@ethersproject/logger" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
 
-"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
   integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
@@ -185,7 +185,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.7.0"
 
-"@ethersproject/contracts@5.7.0":
+"@ethersproject/contracts@5.7.0", "@ethersproject/contracts@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
   integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
@@ -288,7 +288,7 @@
   dependencies:
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/providers@5.7.2":
+"@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.2":
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
   integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
@@ -351,7 +351,7 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
-"@ethersproject/solidity@5.7.0":
+"@ethersproject/solidity@5.7.0", "@ethersproject/solidity@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
   integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
@@ -396,7 +396,7 @@
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
-"@ethersproject/wallet@5.7.0":
+"@ethersproject/wallet@5.7.0", "@ethersproject/wallet@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
   integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
@@ -687,6 +687,21 @@
   integrity sha512-MNqQbzUJZnCMIYvlniC3U+kcavz/PhhQSsY90tbEtUyMj/IQqsLwIRZa4ctjABh3Bz0KCh9OXUZ7Yk/d9hr45Q==
   dependencies:
     ethereumjs-util "^7.1.4"
+
+"@nomicfoundation/hardhat-verify@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.0.1.tgz#440e6ea7538c5485b2fb8fab7ac17b510d8e2d60"
+  integrity sha512-Z++nYMcgbCU3nXkWMVzqAPrhrIyRhrKErWHOWxj0k/GzlhindQzm/D3282mdV4bG9D5qz3+tse9kzhbi1ILCJA==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    lodash.clonedeep "^4.5.0"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
 
 "@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1":
   version "0.1.1"
@@ -1022,7 +1037,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
   integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
-"@types/qs@^6.2.31":
+"@types/qs@^6.2.31", "@types/qs@^6.9.7":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
@@ -1475,6 +1490,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1686,6 +1708,13 @@ catering@^2.1.0, catering@^2.1.1:
   resolved "https://registry.yarnpkg.com/catering/-/catering-2.1.1.tgz#66acba06ed5ee28d5286133982a927de9a04b510"
   integrity sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==
 
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
+
 chai-as-promised@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
@@ -1748,7 +1777,7 @@ chokidar@3.3.0:
   optionalDependencies:
     fsevents "~2.1.1"
 
-chokidar@3.5.3, chokidar@^3.4.0:
+chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.2:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1858,7 +1887,7 @@ colors@1.4.0, colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -2181,7 +2210,12 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-enquirer@^2.3.0:
+encode-utf8@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
+
+enquirer@^2.3.0, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -2620,7 +2654,7 @@ ethereumjs-wallet@1.0.2:
     utf8 "^3.0.0"
     uuid "^8.3.2"
 
-ethers@5.7.2, ethers@^5.3.1, ethers@^5.6.1:
+ethers@5.7.2, ethers@^5.3.1, ethers@^5.5.3, ethers@^5.6.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -2821,7 +2855,14 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.12.1:
+fmix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fmix/-/fmix-0.1.0.tgz#c7bbf124dec42c9d191cfb947d0a9778dd986c0c"
+  integrity sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==
+  dependencies:
+    imul "^1.0.0"
+
+follow-redirects@^1.12.1, follow-redirects@^1.14.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -2845,6 +2886,15 @@ form-data@^2.2.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -2881,6 +2931,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
@@ -3199,6 +3258,36 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+hardhat-deploy@0.11.30:
+  version "0.11.30"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.30.tgz#d47203b584446dce8136ac6d0a96fce2827fb532"
+  integrity sha512-FpMP1zSa24NEARVh/vwFCJJa9Gws3SBRZbVIDYMIvleoH3yOwFcdWY68zfGoxrm4kRHNcaiVNAXVFTm0enKR0A==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/providers" "^5.7.2"
+    "@ethersproject/solidity" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wallet" "^5.7.0"
+    "@types/qs" "^6.9.7"
+    axios "^0.21.1"
+    chalk "^4.1.2"
+    chokidar "^3.5.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
+    ethers "^5.5.3"
+    form-data "^4.0.0"
+    fs-extra "^10.0.0"
+    match-all "^1.2.6"
+    murmur-128 "^0.2.1"
+    qs "^6.9.4"
+    zksync-web3 "^0.14.3"
+
 hardhat-gas-reporter@1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/hardhat-gas-reporter/-/hardhat-gas-reporter-1.0.9.tgz#9a2afb354bc3b6346aab55b1c02ca556d0e16450"
@@ -3440,6 +3529,11 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+imul@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/imul/-/imul-1.0.1.tgz#9d5867161e8b3de96c2c38d5dc7cb102f35e2ac9"
+  integrity sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3895,6 +3989,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3965,6 +4064,11 @@ markdown-table@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
+
+match-all@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/match-all/-/match-all-1.2.6.tgz#66d276ad6b49655551e63d3a6ee53e8be0566f8d"
+  integrity sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==
 
 mcl-wasm@^0.7.1:
   version "0.7.9"
@@ -4212,6 +4316,15 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+murmur-128@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/murmur-128/-/murmur-128-0.2.1.tgz#a9f6568781d2350ecb1bf80c14968cadbeaa4b4d"
+  integrity sha512-WseEgiRkI6aMFBbj8Cg9yBj/y+OdipwVC7zUo3W2W1JAJITwouUOtpqsmGSg67EQmwwSyod7hsVsWY5LsrfQVg==
+  dependencies:
+    encode-utf8 "^1.0.2"
+    fmix "^0.1.0"
+    imul "^1.0.0"
+
 my-easy-fp@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/my-easy-fp/-/my-easy-fp-0.9.0.tgz#cd785f2aa4c4a2bb091c6b49c74500b2094f654f"
@@ -4269,6 +4382,11 @@ node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
   integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 nopt@3.x:
   version "3.0.6"
@@ -4600,6 +4718,13 @@ qs@^6.4.0, qs@^6.7.0:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.1.tgz#6c29dff97f0c0060765911ba65cbc9764186109f"
   integrity sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.9.4:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
+  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
   dependencies:
     side-channel "^1.0.4"
 
@@ -5350,7 +5475,7 @@ table-layout@^1.0.2:
     typical "^5.2.0"
     wordwrapjs "^4.0.0"
 
-table@^6.8.1:
+table@^6.8.0, table@^6.8.1:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
   integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
@@ -5912,3 +6037,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zksync-web3@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.3.tgz#64ac2a16d597464c3fc4ae07447a8007631c57c9"
+  integrity sha512-hT72th4AnqyLW1d5Jlv8N2B/qhEnl2NePK2A3org7tAa24niem/UAaHMkEvmWI3SF9waYUPtqAtjpf+yvQ9zvQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,7 +688,7 @@
   dependencies:
     ethereumjs-util "^7.1.4"
 
-"@nomicfoundation/hardhat-verify@^1.0.1":
+"@nomicfoundation/hardhat-verify@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.0.1.tgz#440e6ea7538c5485b2fb8fab7ac17b510d8e2d60"
   integrity sha512-Z++nYMcgbCU3nXkWMVzqAPrhrIyRhrKErWHOWxj0k/GzlhindQzm/D3282mdV4bG9D5qz3+tse9kzhbi1ILCJA==


### PR DESCRIPTION
Added function `deployAndGetContract` to `src/utils.ts`.
This function uses the `deploy` function from the `hardhat-deploy` plugin and verifies contract on Etherscan afterwards if requested.