### PR TITLE
Patch trackReceivedTokenAndTx method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "repository": {


### PR DESCRIPTION
There is local nodes (like zksync) which return promise's result with await before blockchain state changed.
It works correct when we check `postBalance` after `await txResult.wait();`