### PR TITLE
assertRoughlyEquals

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains frequently used smart contracts, libraries and interfac
 |--|--|--|
 |asserts|`assertThrowsAsync(action, msg)`|checks the async function `action()` thrown with message `msg`|
 |asserts|`assertRoughlyEqualValues(expected, actual, relativeDiff)`|checks the `expected` value is equal to `actual` value with `relativeDiff` precision|
+|asserts|`assertRoughlyEquals(expected, actual, significantDigits)`|checks if two numeric values are approximately equal within a given precision defined by a specified number of significant digits. It throws an error if the values have different signs or if their difference exceeds the allowed tolerance|
 |utils|`timeIncreaseTo(seconds)`|increases blockchain time to `seconds` sec|
 |utils|`trackReceivedToken(token, wallet, txPromise, ...args)`|returns amount of `token` which recieved the `wallet` in async method `txPromise` with arguments `args`|
 |utils|`trackReceivedTokenAndTx(token, wallet, txPromise, ...args)`|returns transaction info and amount of `token` which recieved the `wallet` in async method `txPromise` with arguments `args`|
@@ -68,7 +69,7 @@ Add to `package.json` file solidity compiler version and shortcut to run command
 
 #### Dependencies list (imports-list)
 
-Lists all imports recursively for the given solidity contract file. 
+Lists all imports recursively for the given solidity contract file.
 
 ##### Usage
 ```
@@ -82,13 +83,13 @@ Options:
   -a, --alias [alias...]  projects alias list
   -h, --help              display help for command
 ```
-Aliases are used to provide source code for third-party projects. 
+Aliases are used to provide source code for third-party projects.
 For example, your contract uses imports from your other project and import is defined as
 ```
 import "@1inch/otherproject/contracts/dependency.sol";
 ```
 and you've got source code for `@1inch/otherproject` locally. Then you provide local path for the project to rip dependencies from `dependency.sol` as well.
-If there are several dependencies they should be provided using space as separator. 
+If there are several dependencies they should be provided using space as separator.
 
 ##### Example
 File imports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "repository": {

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -1,5 +1,28 @@
 import { expect } from './prelude';
 
+export function assertRoughlyEquals(
+    expected: string | number | bigint,
+    actual: string | number | bigint,
+    significantDigits: number,
+) {
+    expect(significantDigits).to.be.gte(1, 'significantDigits must be more than 1');
+
+    let expectedBN = BigInt(expected);
+    let actualBN = BigInt(actual);
+    expect(expectedBN * actualBN).to.be.gte(0, 'Values are of different sign');
+
+    if (expectedBN < 0) expectedBN = -expectedBN;
+    if (actualBN < 0) actualBN = -actualBN;
+
+    const differenceBN = expectedBN > actualBN ? expectedBN - actualBN : actualBN - expectedBN;
+    const minExpectedOrActualBN = expectedBN < actualBN ? expectedBN : actualBN;
+
+    const valid = differenceBN * (10n ** BigInt(significantDigits - 1)) < minExpectedOrActualBN;
+    if (!valid) {
+        expect(expected).to.equal(actual, `${expected} != ${actual} with at least ${significantDigits} significant digits`);
+    }
+}
+
 export function assertRoughlyEqualValues(
     expected: string | number | bigint,
     actual: string | number | bigint,

--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -19,7 +19,7 @@ export function assertRoughlyEquals(
 
     const valid = differenceBN * (10n ** BigInt(significantDigits - 1)) < minExpectedOrActualBN;
     if (!valid) {
-        expect(expected).to.equal(actual, `${expected} != ${actual} with at least ${significantDigits} significant digits`);
+        expect(actualBN).to.equal(expectedBN, `${actual} != ${expected} with at least ${significantDigits} significant digits`);
     }
 }
 

--- a/test/asserts.test.ts
+++ b/test/asserts.test.ts
@@ -1,5 +1,49 @@
 import { expect } from '../src/prelude';
-import { assertRoughlyEqualValues } from '../src/asserts';
+import { assertRoughlyEquals, assertRoughlyEqualValues } from '../src/asserts';
+
+describe('assertRoughlyEquals', function () {
+    it('should be work when values are identical', async function () {
+        assertRoughlyEquals(1000000, 1000000, 1);
+    });
+
+    it('should be work when values are identical, even when significantDigits exceed the number of digits in the values', async function () {
+        assertRoughlyEquals(1000000, 1000000, 10);
+    });
+
+    it('should be work when the difference between values is less than the significantDigits', async function () {
+        assertRoughlyEquals(1000001, 1000000, 6);
+    });
+
+    it('should be work when the difference between values is less but negative, relative to the significantDigits', async function () {
+        assertRoughlyEquals(1000000, 1000001, 6);
+    });
+
+    it('should throw when significantDigits less than 1', async function () {
+        expect(() => assertRoughlyEquals(1000000, 1000000, 0)).throws();
+        expect(() => assertRoughlyEquals(1000000, 1000000, -2)).throws();
+    });
+
+    it('should throw when values have different signs', async function () {
+        expect(() => assertRoughlyEquals(1000001, -1000000, 1)).throws();
+    });
+
+    it('should throw when values differ on the last significant digit', async function () {
+        expect(() => assertRoughlyEquals(1000000, 1000001, 7)).throws();
+    });
+
+    it('should throw when difference exceeds the significant digits count', async function () {
+        expect(() => assertRoughlyEquals(1012345, 1000000, 3)).throws();
+    });
+
+    it('should throw even when significant digits count is increased, but difference still exceeds it', async function () {
+        expect(() => assertRoughlyEquals(1012345, 1000000, 4)).throws();
+    });
+
+    it('should handle negative values correctly', async function () {
+        assertRoughlyEquals(-1000001, -1000000, 6);
+        expect(() => assertRoughlyEquals(-1012345, -1000000, 4)).throws();
+    });
+});
 
 describe('assertRoughlyEqualValues', function () {
     it('should be work with expected = actual, any relativeDiff', async function () {

--- a/test/asserts.test.ts
+++ b/test/asserts.test.ts
@@ -18,6 +18,11 @@ describe('assertRoughlyEquals', function () {
         assertRoughlyEquals(1000000, 1000001, 6);
     });
 
+    it('should not throw error when difference is within permitted range', async function () {
+        assertRoughlyEquals(1000000, 999999, 6);
+        assertRoughlyEquals(1000009, 1000010, 6);
+    });
+
     it('should throw when significantDigits less than 1', async function () {
         expect(() => assertRoughlyEquals(1000000, 1000000, 0)).throws();
         expect(() => assertRoughlyEquals(1000000, 1000000, -2)).throws();


### PR DESCRIPTION
The `assertRoughlyEquals` function checks if two numeric values are approximately equal within a given precision defined by a specified number of significant digits. It throws an error if the values have different signs or if their difference exceeds the allowed tolerance