### PR TITLE
[SC-1116] Change zksync testnet network

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -146,7 +146,7 @@ export class Networks {
         // For 'zksyncFork' network you should use zksync fork node: https://github.com/matter-labs/era-test-node
         this.registerZksync('zksyncFork', 260, process.env.ZKSYNC_FORK_RPC_URL, 'mainnet', process.env.ZKSYNC_FORK_PRIVATE_KEY || privateKey);
         this.registerZksync('zksyncLocal', 270, process.env.ZKSYNC_LOCAL_RPC_URL, process.env.ZKSYNC_LOCAL_ETH_NETWORK, process.env.ZKSYNC_PRIVATE_KEY || privateKey);
-        this.registerZksync('zksyncTest', 280, process.env.ZKSYNC_TEST_RPC_URL, 'goerli', process.env.ZKSYNC_TEST_PRIVATE_KEY || privateKey, process.env.ZKSYNC_TEST_VERIFY_URL);
+        this.registerZksync('zksyncTest', 300, process.env.ZKSYNC_TEST_RPC_URL, 'sepolia', process.env.ZKSYNC_TEST_PRIVATE_KEY || privateKey, process.env.ZKSYNC_TEST_VERIFY_URL);
         return { networks: this.networks, etherscan: this.etherscan };
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):
--

#### Dynamic Code Analysis (external APIs, interaction flows):
Migrate deprecated zkSync Goerli testnet to the new zkSync Sepolia testnet, because Goerli was sunseted on March 31st.

#### Efficiency (gas costs, computational complexity, memory requirements):
--

#### Opinion, trade-offs and other thoughts (optional):
--