### PR TITLE
[SC-1177] Deploy with create3 and save deployment

### DIFF
--- a/contracts/tests/mocks/Create3Mock.sol
+++ b/contracts/tests/mocks/Create3Mock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@0xsequence/create3/contracts/Create3.sol";
+
+contract Create3Mock {
+    function deploy(bytes32 salt, bytes calldata code) external returns (address) {
+        return Create3.create3(salt, code);
+    }
+
+    function addressOf(bytes32 salt) external view returns (address) {
+        return Create3.addressOf(salt);
+    }
+}
+
+

--- a/docs/js/classes/hardhat_setup.Networks.md
+++ b/docs/js/classes/hardhat_setup.Networks.md
@@ -47,7 +47,7 @@ See the [README](https://github.com/1inch/solidity-utils/tree/master/hardhat-set
 
 #### Defined in
 
-[hardhat-setup/networks.ts:75](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L75)
+[hardhat-setup/networks.ts:75](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L75)
 
 ## Properties
 
@@ -57,7 +57,7 @@ See the [README](https://github.com/1inch/solidity-utils/tree/master/hardhat-set
 
 #### Defined in
 
-[hardhat-setup/networks.ts:73](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L73)
+[hardhat-setup/networks.ts:73](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L73)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[hardhat-setup/networks.ts:72](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L72)
+[hardhat-setup/networks.ts:72](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L72)
 
 ## Methods
 
@@ -93,7 +93,7 @@ ___
 
 #### Defined in
 
-[hardhat-setup/networks.ts:96](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L96)
+[hardhat-setup/networks.ts:96](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L96)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[hardhat-setup/networks.ts:139](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L139)
+[hardhat-setup/networks.ts:139](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L139)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[hardhat-setup/networks.ts:113](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L113)
+[hardhat-setup/networks.ts:113](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L113)
 
 ___
 
@@ -165,4 +165,4 @@ ___
 
 #### Defined in
 
-[hardhat-setup/networks.ts:120](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L120)
+[hardhat-setup/networks.ts:120](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L120)

--- a/docs/js/enums/src.NonceType.md
+++ b/docs/js/enums/src.NonceType.md
@@ -22,7 +22,7 @@ Enum defining types of nonces.
 
 #### Defined in
 
-[src/bySig.ts:10](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L10)
+[src/bySig.ts:10](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L10)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[src/bySig.ts:11](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L11)
+[src/bySig.ts:11](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L11)
 
 ___
 
@@ -42,4 +42,4 @@ ___
 
 #### Defined in
 
-[src/bySig.ts:12](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L12)
+[src/bySig.ts:12](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L12)

--- a/docs/js/interfaces/src.DeployContractOptions.md
+++ b/docs/js/interfaces/src.DeployContractOptions.md
@@ -81,7 +81,7 @@ Number of confirmations to wait based on network. Ussually it's need for waiting
 
 #### Defined in
 
-[src/utils.ts:29](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L29)
+[src/utils.ts:31](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L31)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:27](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L27)
+[src/utils.ts:29](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L29)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:31](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L31)
+[src/utils.ts:33](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L33)
 
 ___
 
@@ -111,23 +111,17 @@ ___
 
 #### Defined in
 
-[src/utils.ts:32](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L32)
+[src/utils.ts:34](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L34)
 
 ___
 
 ### deployments
 
-• **deployments**: `Object`
-
-#### Type declaration
-
-| Name | Type |
-| :------ | :------ |
-| `deploy` | (`name`: `string`, `options`: `DeployOptions`) => `Promise`\<`DeployResult`\> |
+• **deployments**: `DeploymentsExtension`
 
 #### Defined in
 
-[src/utils.ts:30](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L30)
+[src/utils.ts:32](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L32)
 
 ___
 
@@ -137,7 +131,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:35](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L35)
+[src/utils.ts:37](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L37)
 
 ___
 
@@ -147,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:38](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L38)
+[src/utils.ts:40](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L40)
 
 ___
 
@@ -157,7 +151,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:37](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L37)
+[src/utils.ts:39](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L39)
 
 ___
 
@@ -167,7 +161,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:36](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L36)
+[src/utils.ts:38](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L38)
 
 ___
 
@@ -177,7 +171,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:34](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L34)
+[src/utils.ts:36](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L36)
 
 ___
 
@@ -187,7 +181,7 @@ ___
 
 #### Defined in
 
-[src/utils.ts:33](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L33)
+[src/utils.ts:35](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L35)
 
 ___
 
@@ -197,4 +191,4 @@ ___
 
 #### Defined in
 
-[src/utils.ts:39](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L39)
+[src/utils.ts:41](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L41)

--- a/docs/js/interfaces/src.SignedCallStruct.md
+++ b/docs/js/interfaces/src.SignedCallStruct.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[src/bySig.ts:51](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L51)
+[src/bySig.ts:51](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L51)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[src/bySig.ts:50](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L50)
+[src/bySig.ts:50](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L50)

--- a/docs/js/modules/hardhat_setup.md
+++ b/docs/js/modules/hardhat_setup.md
@@ -45,7 +45,7 @@ Array of custom blockchain network configurations.
 
 #### Defined in
 
-[hardhat-setup/networks.ts:11](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L11)
+[hardhat-setup/networks.ts:11](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L11)
 
 ___
 
@@ -65,7 +65,7 @@ A helper method to get the network name from the command line arguments.
 
 #### Defined in
 
-[hardhat-setup/networks.ts:21](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L21)
+[hardhat-setup/networks.ts:21](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L21)
 
 ___
 
@@ -96,7 +96,7 @@ A helper method to parse RPC configuration strings. Checks that the string is in
 
 #### Defined in
 
-[hardhat-setup/networks.ts:32](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L32)
+[hardhat-setup/networks.ts:32](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L32)
 
 ___
 
@@ -121,4 +121,4 @@ A helper method to reset the Hardhat network to the local network or to a fork.
 
 #### Defined in
 
-[hardhat-setup/networks.ts:46](https://github.com/1inch/solidity-utils/blob/dc69769/hardhat-setup/networks.ts#L46)
+[hardhat-setup/networks.ts:46](https://github.com/1inch/solidity-utils/blob/99d1aa1/hardhat-setup/networks.ts#L46)

--- a/docs/js/modules/src.md
+++ b/docs/js/modules/src.md
@@ -40,6 +40,7 @@
 - [cutSelector](src.md#cutselector)
 - [decompressPermit](src.md#decompresspermit)
 - [deployAndGetContract](src.md#deployandgetcontract)
+- [deployAndGetContractWithCreate3](src.md#deployandgetcontractwithcreate3)
 - [deployContract](src.md#deploycontract)
 - [deployContractFromBytecode](src.md#deploycontractfrombytecode)
 - [domainSeparator](src.md#domainseparator)
@@ -54,6 +55,7 @@
 - [hashBySig](src.md#hashbysig)
 - [permit2Contract](src.md#permit2contract)
 - [profileEVM](src.md#profileevm)
+- [saveContractWithCreate3Deployment](src.md#savecontractwithcreate3deployment)
 - [signMessage](src.md#signmessage)
 - [signSignedCall](src.md#signsignedcall)
 - [timeIncreaseTo](src.md#timeincreaseto)
@@ -69,7 +71,7 @@
 
 #### Defined in
 
-[src/permit.ts:30](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L30)
+[src/permit.ts:30](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L30)
 
 ___
 
@@ -79,7 +81,7 @@ ___
 
 #### Defined in
 
-[src/permit.ts:15](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L15)
+[src/permit.ts:15](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L15)
 
 ___
 
@@ -89,7 +91,7 @@ ___
 
 #### Defined in
 
-[src/permit.ts:22](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L22)
+[src/permit.ts:22](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L22)
 
 ___
 
@@ -99,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/permit.ts:11](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L11)
+[src/permit.ts:11](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L11)
 
 ___
 
@@ -124,7 +126,7 @@ ___
 
 #### Defined in
 
-[src/prelude.ts:4](https://github.com/1inch/solidity-utils/blob/dc69769/src/prelude.ts#L4)
+[src/prelude.ts:4](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/prelude.ts#L4)
 
 ___
 
@@ -134,7 +136,7 @@ ___
 
 #### Defined in
 
-[src/permit.ts:12](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L12)
+[src/permit.ts:12](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L12)
 
 ___
 
@@ -144,7 +146,7 @@ ___
 
 #### Defined in
 
-[src/permit.ts:13](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L13)
+[src/permit.ts:13](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L13)
 
 ___
 
@@ -176,7 +178,7 @@ Error if provided with invalid parameters.
 
 #### Defined in
 
-[src/bySig.ts:24](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L24)
+[src/bySig.ts:24](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L24)
 
 ___
 
@@ -204,7 +206,7 @@ The EIP-712 hash of the fully encoded data.
 
 #### Defined in
 
-[src/bySig.ts:63](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L63)
+[src/bySig.ts:63](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L63)
 
 ___
 
@@ -233,7 +235,7 @@ A Promise that resolves to the signature.
 
 #### Defined in
 
-[src/bySig.ts:84](https://github.com/1inch/solidity-utils/blob/dc69769/src/bySig.ts#L84)
+[src/bySig.ts:84](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/bySig.ts#L84)
 
 ## expect
 
@@ -265,7 +267,7 @@ or if the actual value deviates from the expected by more than the specified rel
 
 #### Defined in
 
-[src/expect.ts:15](https://github.com/1inch/solidity-utils/blob/dc69769/src/expect.ts#L15)
+[src/expect.ts:15](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/expect.ts#L15)
 
 ## permit
 
@@ -313,7 +315,7 @@ Constructs structured data for EIP-2612 permit function, including types, domain
 
 #### Defined in
 
-[src/permit.ts:97](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L97)
+[src/permit.ts:97](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L97)
 
 ___
 
@@ -363,7 +365,7 @@ Prepares structured data similar to the Dai permit function, including types, do
 
 #### Defined in
 
-[src/permit.ts:129](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L129)
+[src/permit.ts:129](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L129)
 
 ___
 
@@ -392,7 +394,7 @@ Compresses a permit function call to a shorter format based on its type.
 
 #### Defined in
 
-[src/permit.ts:352](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L352)
+[src/permit.ts:352](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L352)
 
 ___
 
@@ -418,7 +420,7 @@ Trims the method selector from transaction data, removing the first 8 characters
 
 #### Defined in
 
-[src/permit.ts:58](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L58)
+[src/permit.ts:58](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L58)
 
 ___
 
@@ -447,7 +449,7 @@ Decompresses a compressed permit function call back to its original full format.
 
 #### Defined in
 
-[src/permit.ts:401](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L401)
+[src/permit.ts:401](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L401)
 
 ___
 
@@ -476,7 +478,7 @@ Generates a domain separator for EIP-712 structured data using the provided para
 
 #### Defined in
 
-[src/permit.ts:72](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L72)
+[src/permit.ts:72](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L72)
 
 ___
 
@@ -509,7 +511,7 @@ Generates a permit signature for ERC20 tokens with EIP-2612 standard.
 
 #### Defined in
 
-[src/permit.ts:172](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L172)
+[src/permit.ts:172](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L172)
 
 ___
 
@@ -542,7 +544,7 @@ Creates a permit for spending tokens on Permit2 standard contracts.
 
 #### Defined in
 
-[src/permit.ts:214](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L214)
+[src/permit.ts:214](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L214)
 
 ___
 
@@ -575,7 +577,7 @@ Generates a Dai-like permit signature for tokens.
 
 #### Defined in
 
-[src/permit.ts:256](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L256)
+[src/permit.ts:256](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L256)
 
 ___
 
@@ -608,7 +610,7 @@ Generates a ERC-7597 permit signature for tokens.
 
 #### Defined in
 
-[src/permit.ts:301](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L301)
+[src/permit.ts:301](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L301)
 
 ___
 
@@ -628,7 +630,7 @@ Ensures contract code is set for a given address and returns a contract instance
 
 #### Defined in
 
-[src/permit.ts:152](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L152)
+[src/permit.ts:152](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L152)
 
 ___
 
@@ -654,7 +656,7 @@ Removes the '0x' prefix from a string. If no '0x' prefix is found, returns the o
 
 #### Defined in
 
-[src/permit.ts:44](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L44)
+[src/permit.ts:44](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L44)
 
 ___
 
@@ -681,7 +683,7 @@ Concatenates a target address with data, trimming the '0x' prefix from the data.
 
 #### Defined in
 
-[src/permit.ts:339](https://github.com/1inch/solidity-utils/blob/dc69769/src/permit.ts#L339)
+[src/permit.ts:339](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/permit.ts#L339)
 
 ## prelude
 
@@ -707,7 +709,7 @@ Converts an Ether amount represented as a string into its Wei equivalent as a bi
 
 #### Defined in
 
-[src/prelude.ts:26](https://github.com/1inch/solidity-utils/blob/dc69769/src/prelude.ts#L26)
+[src/prelude.ts:26](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/prelude.ts#L26)
 
 ## profileEVM
 
@@ -729,7 +731,7 @@ Default configuration options for the `gasspectEVM` function to analyze gas usag
 
 #### Defined in
 
-[src/profileEVM.ts:11](https://github.com/1inch/solidity-utils/blob/dc69769/src/profileEVM.ts#L11)
+[src/profileEVM.ts:11](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/profileEVM.ts#L11)
 
 ___
 
@@ -759,7 +761,7 @@ Analyzes gas usage by operations within a transaction, applying filters and form
 
 #### Defined in
 
-[src/profileEVM.ts:141](https://github.com/1inch/solidity-utils/blob/dc69769/src/profileEVM.ts#L141)
+[src/profileEVM.ts:141](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/profileEVM.ts#L141)
 
 ___
 
@@ -788,7 +790,7 @@ Profiles EVM execution by counting occurrences of specified instructions in a tr
 
 #### Defined in
 
-[src/profileEVM.ts:112](https://github.com/1inch/solidity-utils/blob/dc69769/src/profileEVM.ts#L112)
+[src/profileEVM.ts:112](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/profileEVM.ts#L112)
 
 ## utils
 
@@ -806,7 +808,7 @@ allowing for handling of complex scenarios like chained or batched transactions 
 
 #### Defined in
 
-[src/utils.ts:164](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L164)
+[src/utils.ts:294](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L294)
 
 ___
 
@@ -834,7 +836,7 @@ Counts the occurrences of specified EVM instructions in a transaction's executio
 
 #### Defined in
 
-[src/utils.ts:238](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L238)
+[src/utils.ts:368](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L368)
 
 ___
 
@@ -846,7 +848,7 @@ ___
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `options` | [`DeployContractOptions`](../interfaces/src.DeployContractOptions.md) | Deployment options. Default values: - deploymentName: contractName - skipVerify: false - skipIfAlreadyDeployed: true - log: true - waitConfirmations: 1 on dev chains, 6 on others |
+| `options` | [`DeployContractOptions`](../interfaces/src.DeployContractOptions.md) | Deployment options. Default values: - constructorArgs: [] - deploymentName: contractName - skipVerify: false - skipIfAlreadyDeployed: true - log: true - waitConfirmations: 1 on dev chains, 6 on others |
 
 #### Returns
 
@@ -860,7 +862,33 @@ Deploys a contract with optional Etherscan verification.
 
 #### Defined in
 
-[src/utils.ts:53](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L53)
+[src/utils.ts:69](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L69)
+
+___
+
+### deployAndGetContractWithCreate3
+
+▸ **deployAndGetContractWithCreate3**(`options`): `Promise`\<`Contract`\>
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options` | `DeployContractOptionsWithCreate3` | Deployment options. Default values: - constructorArgs: [] - txSigner: first signer in the environment - deploymentName: contractName - skipVerify: false - waitConfirmations: 1 on dev chains, 6 on others |
+
+#### Returns
+
+`Promise`\<`Contract`\>
+
+The deployed contract instance.
+
+**`Notice`**
+
+Deploys a contract using create3 and saves the deployment information.
+
+#### Defined in
+
+[src/utils.ts:130](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L130)
 
 ___
 
@@ -887,7 +915,7 @@ Deploys a contract given a name and optional constructor parameters.
 
 #### Defined in
 
-[src/utils.ts:120](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L120)
+[src/utils.ts:250](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L250)
 
 ___
 
@@ -916,7 +944,7 @@ Deploys a contract from bytecode, useful for testing and deployment of minimal p
 
 #### Defined in
 
-[src/utils.ts:137](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L137)
+[src/utils.ts:267](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L267)
 
 ___
 
@@ -942,7 +970,7 @@ Corrects the ECDSA signature 'v' value according to Ethereum's standard.
 
 #### Defined in
 
-[src/utils.ts:204](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L204)
+[src/utils.ts:334](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L334)
 
 ___
 
@@ -972,7 +1000,41 @@ important part of test.
 
 #### Defined in
 
-[src/utils.ts:263](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L263)
+[src/utils.ts:393](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L393)
+
+___
+
+### saveContractWithCreate3Deployment
+
+▸ **saveContractWithCreate3Deployment**(`provider`, `deployments`, `contractName`, `deploymentName`, `constructorArgs`, `salt`, `create3Deployer`, `deployTxHash`, `skipVerify?`): `Promise`\<`Contract`\>
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `provider` | `HardhatEthersProvider` \| `JsonRpcProvider` | `undefined` | JSON RPC provider or Hardhat Ethers Provider. |
+| `deployments` | `DeploymentsExtension` | `undefined` | Deployment facilitator object from Hardhat. |
+| `contractName` | `string` | `undefined` | Name of the contract to deploy. |
+| `deploymentName` | `string` | `undefined` | Optional custom name for deployment. |
+| `constructorArgs` | `any`[] | `undefined` | Arguments for the contract's constructor. |
+| `salt` | `string` | `undefined` | Salt value for create3 deployment. |
+| `create3Deployer` | `string` | `undefined` | Address of the create3 deployer contract. |
+| `deployTxHash` | `string` | `undefined` | Transaction hash of the create3 deployment. |
+| `skipVerify` | `boolean` | `false` | Skips Etherscan verification if true. |
+
+#### Returns
+
+`Promise`\<`Contract`\>
+
+The deployed contract instance.
+
+**`Notice`**
+
+Saves the deployment information using the deploy transaction hash.
+
+#### Defined in
+
+[src/utils.ts:188](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L188)
 
 ___
 
@@ -999,7 +1061,7 @@ Signs a message with a given signer and fixes the signature format.
 
 #### Defined in
 
-[src/utils.ts:223](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L223)
+[src/utils.ts:353](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L353)
 
 ___
 
@@ -1023,7 +1085,7 @@ Advances the blockchain time to a specific timestamp for testing purposes.
 
 #### Defined in
 
-[src/utils.ts:107](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L107)
+[src/utils.ts:237](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L237)
 
 ___
 
@@ -1060,7 +1122,7 @@ It could be used recursively for multiple tokens via specific `txPromise` functi
 
 #### Defined in
 
-[src/utils.ts:177](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L177)
+[src/utils.ts:307](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L307)
 
 ## utils
 Represents the interface for a token, providing methods to fetch its balance and address.
@@ -1087,4 +1149,4 @@ Method which retrieves the token contract's address.
 
 #### Defined in
 
-[src/utils.ts:151](https://github.com/1inch/solidity-utils/blob/dc69769/src/utils.ts#L151)
+[src/utils.ts:281](https://github.com/1inch/solidity-utils/blob/99d1aa1/src/utils.ts#L281)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "node-fetch": "2.7.0"
   },
   "devDependencies": {
+    "@0xsequence/create3": "0xsequence/create3",
     "@nomicfoundation/hardhat-chai-matchers": "2.0.6",
     "@typechain/ethers-v6": "0.5.1",
     "@typechain/hardhat": "9.1.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,13 @@
 import '@nomicfoundation/hardhat-ethers';  // required to populate the HardhatRuntimeEnvironment with ethers
 import hre, { ethers } from 'hardhat';
 import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import fetch from 'node-fetch';
-import { BaseContract, BigNumberish, BytesLike, Contract, ContractTransactionReceipt, ContractTransactionResponse, JsonRpcProvider, Signer, Wallet } from 'ethers';
-import { DeployOptions, DeployResult } from 'hardhat-deploy/types';
+import { BaseContract, BigNumberish, BytesLike, Contract, ContractTransactionReceipt, ContractTransactionResponse, JsonRpcProvider, Signer, TransactionReceipt, Wallet } from 'ethers';
+import { DeployOptions, DeployResult, Deployment, DeploymentsExtension, Receipt } from 'hardhat-deploy/types';
 
 import { constants } from './prelude';
+import { HardhatEthersProvider } from '@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider';
 
 /**
  * @category utils
@@ -27,7 +29,7 @@ export interface DeployContractOptions {
     contractName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     constructorArgs?: any[];
-    deployments: { deploy: (name: string, options: DeployOptions) => Promise<DeployResult> },
+    deployments: DeploymentsExtension,
     deployer: string;
     deploymentName?: string;
     skipVerify?: boolean;
@@ -39,10 +41,17 @@ export interface DeployContractOptions {
     waitConfirmations?: number;
 }
 
+interface DeployContractOptionsWithCreate3 extends Omit<DeployContractOptions, 'deployer' | 'skipIfAlreadyDeployed'> {
+    txSigner?: Wallet | SignerWithAddress,
+    create3Deployer: string,
+    salt: string,
+}
+
 /**
  * @category utils
  * @notice Deploys a contract with optional Etherscan verification.
  * @param options Deployment options. Default values:
+ *    - constructorArgs: []
  *    - deploymentName: contractName
  *    - skipVerify: false
  *    - skipIfAlreadyDeployed: true
@@ -54,7 +63,7 @@ export async function deployAndGetContract(options: DeployContractOptions): Prom
     // Set default values for options
     const {
         contractName,
-        constructorArgs,
+        constructorArgs = [],
         deployments,
         deployer,
         deploymentName = contractName,
@@ -86,6 +95,7 @@ export async function deployAndGetContract(options: DeployContractOptions): Prom
         log,
         waitConfirmations,
     };
+    // If hardhat-deploy `deploy` function logs need to be displayed, add HARDHAT_DEPLOY_LOG = 'true' to the .env file
     const deployResult: DeployResult = await deploy(deploymentName, deployOptions);
 
     if (!(skipVerify || constants.DEV_CHAINS.includes(hre.network.name))) {
@@ -97,6 +107,94 @@ export async function deployAndGetContract(options: DeployContractOptions): Prom
         console.log('Skipping verification');
     }
     return await ethers.getContractAt(contractName, deployResult.address);
+}
+
+export async function deployAndGetContractWithCreate3(
+    options: DeployContractOptionsWithCreate3,
+): Promise<Contract> {
+    // Set default values for options
+    const {
+        create3Deployer,
+        salt,
+        contractName,
+        constructorArgs = [],
+        deployments,
+        txSigner = (await ethers.getSigners())[0],
+        deploymentName = contractName,
+        skipVerify = false,
+        gasPrice,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        waitConfirmations = constants.DEV_CHAINS.includes(hre.network.name) ? 1 : 6,
+    } = options;
+
+    const deployer = await ethers.getContractAt('ICreate3Deployer', create3Deployer);
+    const CustomContract = await ethers.getContractFactory(contractName);
+    const deployData = (await CustomContract.getDeployTransaction(
+        ...constructorArgs,
+    )).data;
+
+    const txn = await deployer.connect(txSigner).deploy(salt, deployData, { gasPrice, maxPriorityFeePerGas, maxFeePerGas });
+    const receipt = await txn.wait(waitConfirmations) as TransactionReceipt;
+
+    const customContractAddress = await deployer.addressOf(salt);
+    console.log(`${contractName} deployed to: ${customContractAddress}`);
+
+    return await saveContractWithCreate3Deployment(
+        txSigner.provider as JsonRpcProvider,
+        deployments,
+        contractName,
+        deploymentName,
+        constructorArgs,
+        salt,
+        create3Deployer,
+        receipt.hash,
+        skipVerify,
+    );
+}
+
+export async function saveContractWithCreate3Deployment(
+    provider: JsonRpcProvider | HardhatEthersProvider,
+    deployments: DeploymentsExtension,
+    contractName: string,
+    deploymentName: string,
+    constructorArgs: any[], // eslint-disable-line @typescript-eslint/no-explicit-any
+    salt: string,
+    create3Deployer: string,
+    deployTxHash: string,
+    skipVerify: boolean = false,
+): Promise<Contract> {
+    const deployer = await ethers.getContractAt('ICreate3Deployer', create3Deployer);
+    const contract = await deployer.addressOf(salt);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const receipt = await provider.getTransactionReceipt(deployTxHash) as {[key: string]: any};
+    if (receipt != null) {
+        // conver ethers.TransactionReceipt object to hardhat-deploy.Receipt object
+        receipt.transactionHash = receipt.hash;
+        receipt.transactionIndex = receipt.index;
+        ['provider', 'blobGasPrice', 'type', 'root', 'hash', 'index'].forEach(key => delete receipt[key]);
+    }
+
+    if (!(skipVerify || constants.DEV_CHAINS.includes(hre.network.name))) {
+        await hre.run('verify:verify', {
+            address: contract,
+            constructorArguments: constructorArgs,
+        });
+    } else {
+        console.log('Skipping verification');
+    }
+
+    const ContractArtifact = await deployments.getArtifact(contractName);
+    const ContractDeploymentData = {} as Deployment;
+    ContractDeploymentData.address = contract;
+    ContractDeploymentData.transactionHash = receipt.hash;
+    ContractDeploymentData.receipt = receipt as Receipt;
+    ContractDeploymentData.args = constructorArgs;
+    ContractDeploymentData.abi = ContractArtifact.abi;
+    ContractDeploymentData.bytecode = ContractArtifact.bytecode;
+    ContractDeploymentData.deployedBytecode = ContractArtifact.deployedBytecode;
+    await deployments.save(deploymentName, ContractDeploymentData);
+    return await ethers.getContractAt(contractName, contract);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,13 @@ export interface DeployContractOptions {
     waitConfirmations?: number;
 }
 
+/**
+ * @category utils
+ * @notice Options for deployment methods with create3. This is an extension of DeployContractOptions without `deployer` and `skipIfAlreadyDeployed`.
+ * @param txSigner Signer object to sign the deployment transaction.
+ * @param create3Deployer Address of the create3 deployer contract.
+ * @param salt Salt value for create3 deployment.
+ */
 interface DeployContractOptionsWithCreate3 extends Omit<DeployContractOptions, 'deployer' | 'skipIfAlreadyDeployed'> {
     txSigner?: Wallet | SignerWithAddress,
     create3Deployer: string,
@@ -109,6 +116,17 @@ export async function deployAndGetContract(options: DeployContractOptions): Prom
     return await ethers.getContractAt(contractName, deployResult.address);
 }
 
+/**
+ * @category utils
+ * @notice Deploys a contract using create3 and saves the deployment information.
+ * @param options Deployment options. Default values:
+ *    - constructorArgs: []
+ *    - txSigner: first signer in the environment
+ *    - deploymentName: contractName
+ *    - skipVerify: false
+ *    - waitConfirmations: 1 on dev chains, 6 on others
+ * @returns The deployed contract instance.
+ */
 export async function deployAndGetContractWithCreate3(
     options: DeployContractOptionsWithCreate3,
 ): Promise<Contract> {
@@ -153,6 +171,20 @@ export async function deployAndGetContractWithCreate3(
     );
 }
 
+/**
+ * @category utils
+ * @notice Saves the deployment information using the deploy transaction hash.
+ * @param provider JSON RPC provider or Hardhat Ethers Provider.
+ * @param deployments Deployment facilitator object from Hardhat.
+ * @param contractName Name of the contract to deploy.
+ * @param deploymentName Optional custom name for deployment.
+ * @param constructorArgs Arguments for the contract's constructor.
+ * @param salt Salt value for create3 deployment.
+ * @param create3Deployer Address of the create3 deployer contract.
+ * @param deployTxHash Transaction hash of the create3 deployment.
+ * @param skipVerify Skips Etherscan verification if true.
+ * @returns The deployed contract instance.
+ */
 export async function saveContractWithCreate3Deployment(
     provider: JsonRpcProvider | HardhatEthersProvider,
     deployments: DeploymentsExtension,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@0xsequence/create3@0xsequence/create3":
+  version "3.0.0"
+  resolved "https://codeload.github.com/0xsequence/create3/tar.gz/acc4703a21ec1d71dc2a99db088c4b1f467530fd"
+  dependencies:
+    csv-writer "^1.6.0"
+
 "@aashutoshrathi/word-wrap@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
@@ -986,65 +992,53 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomicfoundation/edr-darwin-arm64@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.4.tgz#e5aac2b7726f44cffe120bdd7e25e1f120471591"
-  integrity sha512-tjavrUFLWnkn0PI+jk0D83hP2jjbmeXT1QLd5NtIleyGrJ00ZWVl+sfuA2Lle3kzfOceoI2VTR0n1pZB4KJGbQ==
+"@nomicfoundation/edr-darwin-arm64@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.8.tgz#09de1f03c0336670fce959f376f0fe9137545836"
+  integrity sha512-eB0leCexS8sQEmfyD72cdvLj9djkBzQGP4wSQw6SNf2I4Sw4Cnzb3d45caG2FqFFjbvfqL0t+badUUIceqQuMw==
 
-"@nomicfoundation/edr-darwin-x64@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.4.tgz#cbcc0a2dcda0a7c0a900a74efc6918cff134dc23"
-  integrity sha512-dXO0vlIoBosp8gf5/ah3dESMymjwit0Daef1E4Ew3gZ8q3LAdku0RC+YEQJi9f0I3QNfdgIrBTzibRZUoP+kVA==
+"@nomicfoundation/edr-darwin-x64@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.8.tgz#c3ca237c74ed3b6fb800fd7f1de7174f4ad24f72"
+  integrity sha512-JksVCS1N5ClwVF14EvO25HCQ+Laljh/KRfHERMVAC9ZwPbTuAd/9BtKvToCBi29uCHWqsXMI4lxCApYQv2nznw==
 
-"@nomicfoundation/edr-linux-arm64-gnu@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.4.tgz#12073f97d310176bb24ad7d48c25128ea8eff093"
-  integrity sha512-dv38qmFUaqkkeeA9S0JjerqruytTfHav7gbPLpZUAEXPlJGo49R0+HQxd45I0msbm6NAXbkmKEchTLApp1ohaA==
+"@nomicfoundation/edr-linux-arm64-gnu@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.8.tgz#08bd367789e745f4e78a8a87368fc470eea8a7de"
+  integrity sha512-raCE+fOeNXhVBLUo87cgsHSGvYYRB6arih4eG6B9KGACWK5Veebtm9xtKeiD8YCsdUlUfat6F7ibpeNm91fpsA==
 
-"@nomicfoundation/edr-linux-arm64-musl@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.4.tgz#c9bc685d4d14bf21d9c3e326edd44e009e24492d"
-  integrity sha512-CfEsb6gdCMVIlRSpWYTxoongEKHB60V6alE/y8mkfjIo7tA95wyiuvCtyo3fpiia3wQV7XoMYgIJHObHiKLKtA==
+"@nomicfoundation/edr-linux-arm64-musl@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.8.tgz#9cab5cbec0052cb5812c6c66c463d28a756cd916"
+  integrity sha512-PwiDp4wBZWMCIy29eKkv8moTKRrpiSDlrc+GQMSZLhOAm8T33JKKXPwD/2EbplbhCygJDGXZdtEKl9x9PaH66A==
 
-"@nomicfoundation/edr-linux-x64-gnu@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.4.tgz#37486cbe317b8caf7961e500fc0150c45c895a56"
-  integrity sha512-V0CpJA2lYWulgTR+zP11ftBAEwkpMAAki/AuMu3vd7HoPfjwIDzWDQR5KFU17qFmqAVz0ICRxsxDlvvBZ/PUxA==
+"@nomicfoundation/edr-linux-x64-gnu@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.8.tgz#d4a11b6ebcd1b29d7431d185c6df3e65a2cd4bde"
+  integrity sha512-6AcvA/XKoipGap5jJmQ9Y6yT7Uf39D9lu2hBcDCXnXbMcXaDGw4mn1/L4R63D+9VGZyu1PqlcJixCUZlGGIWlg==
 
-"@nomicfoundation/edr-linux-x64-musl@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.4.tgz#399278807100a1833f6c8a39c17d5beaaf7a9223"
-  integrity sha512-0sgTrwZajarukerU/QSb+oRdlQLnJdd7of8OlXq2wtpeTNTqemgCOwY2l2qImbWboMpVrYgcmGbINXNVPCmuJw==
+"@nomicfoundation/edr-linux-x64-musl@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.8.tgz#b8eef960d06380a365866ddd1e97ecb7fbf6bd70"
+  integrity sha512-cxb0sEmZjlwhYWO28sPsV64VDx31ekskhC1IsDXU1p9ntjHSJRmW4KEIqJ2O3QwJap/kLKfMS6TckvY10gjc6w==
 
-"@nomicfoundation/edr-win32-arm64-msvc@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-arm64-msvc/-/edr-win32-arm64-msvc-0.3.4.tgz#879028e2708538fd54efc349c1a4de107a15abb4"
-  integrity sha512-bOl3vhMtV0W9ozUMF5AZRBWw1183hhhx+e1YJdDLMaqNkBUFYi2CZbMYefDylq2OKQtOQ0gPLhZvn+z2D21Ztw==
-
-"@nomicfoundation/edr-win32-ia32-msvc@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-ia32-msvc/-/edr-win32-ia32-msvc-0.3.4.tgz#97d54b8cfbbafa1cd2001bb115e583f1169bf9ae"
-  integrity sha512-yKQCpAX0uB2dalsSwOkau3yfNXkwBJa/Ks2OPl9AjHqJ+E8AqvBEB9jRpfQrdPzElMsgZuN4mqE+wh+JxY+0Aw==
-
-"@nomicfoundation/edr-win32-x64-msvc@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.4.tgz#abfc447eb6bd1a9be868bec5c9d14546398ab609"
-  integrity sha512-fResvsL/fSucep1K5W6iOs8lqqKKovHLsAmigMzAYVovqkyZKgCGVS/D8IVxA0nxuGCOlNxFnVmwWtph3pbKWA==
+"@nomicfoundation/edr-win32-x64-msvc@0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.8.tgz#ac7061aeb07cc847c429513080b76bb05297a869"
+  integrity sha512-yVuVPqRRNLZk7TbBMkKw7lzCvI8XO8fNTPTYxymGadjr9rEGRuNTU1yBXjfJ59I1jJU/X2TSkRk1OFX0P5tpZQ==
 
 "@nomicfoundation/edr@^0.3.1":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr/-/edr-0.3.4.tgz#e8eaf41963460139c47b0785f1a6a2a1c1b24ae0"
-  integrity sha512-e4jzVeJ+VTKBFzNgKDbSVnGVbHYNZHIfMdgifQBugXPiIa6QEUzZqleh2+y4lhkXcCthnFyrTYe3jiEpUzr3cA==
-  optionalDependencies:
-    "@nomicfoundation/edr-darwin-arm64" "0.3.4"
-    "@nomicfoundation/edr-darwin-x64" "0.3.4"
-    "@nomicfoundation/edr-linux-arm64-gnu" "0.3.4"
-    "@nomicfoundation/edr-linux-arm64-musl" "0.3.4"
-    "@nomicfoundation/edr-linux-x64-gnu" "0.3.4"
-    "@nomicfoundation/edr-linux-x64-musl" "0.3.4"
-    "@nomicfoundation/edr-win32-arm64-msvc" "0.3.4"
-    "@nomicfoundation/edr-win32-ia32-msvc" "0.3.4"
-    "@nomicfoundation/edr-win32-x64-msvc" "0.3.4"
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/edr/-/edr-0.3.8.tgz#28fe7ae4f462ae74a16cd1a714ff7b1cd9c22b4c"
+  integrity sha512-u2UJ5QpznSHVkZRh6ePWoeVb6kmPrrqh08gCnZ9FHlJV9CITqlrTQHJkacd+INH31jx88pTAJnxePE4XAiH5qg==
+  dependencies:
+    "@nomicfoundation/edr-darwin-arm64" "0.3.8"
+    "@nomicfoundation/edr-darwin-x64" "0.3.8"
+    "@nomicfoundation/edr-linux-arm64-gnu" "0.3.8"
+    "@nomicfoundation/edr-linux-arm64-musl" "0.3.8"
+    "@nomicfoundation/edr-linux-x64-gnu" "0.3.8"
+    "@nomicfoundation/edr-linux-x64-musl" "0.3.8"
+    "@nomicfoundation/edr-win32-x64-msvc" "0.3.8"
 
 "@nomicfoundation/ethereumjs-common@4.0.4":
   version "4.0.4"
@@ -2567,6 +2561,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
+
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.6.0.tgz#d0cea44b6b4d7d3baa2ecc6f3f7209233514bcf9"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
 
 data-view-buffer@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):

Added a method to save a deployment object after deploying via create3, as `hardhat-deploy` does not support this and contracts deployed via create3 remain without deployments or with outdated ones. This method allows saving up-to-date deployment information.

#### Dynamic Code Analysis (external APIs, interaction flows):

The new method is similar to the `deployAndGetContract` method and is intended for deploying contracts and verifying code, but using for deploy with create3. It provides similar interaction flows and interacts with external APIs in a comparable manner.

#### Efficiency (gas costs, computational complexity, memory requirements):

Efficiency has not been measured as this is an auxiliary JS utility without EVM optimizations. The focus was on functionality and ease of use.

#### Opinion, trade-offs and other thoughts (optional):

- The method creates a deployment object useful for further use and analysis. This facilitates the management and tracking of deployed contracts.
- Using this method simplifies the code, making the deployment process and saving deployment information more straightforward and convenient.