### PR TITLE
Fix comment in ECDSA.sol

### DIFF
--- a/contracts/libraries/ECDSA.sol
+++ b/contracts/libraries/ECDSA.sol
@@ -231,7 +231,7 @@ library ECDSA {
         bytes calldata signature
     ) internal view returns (bool success) {
         // (bool success, bytes memory data) = signer.staticcall(abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature));
-        // return success && data.length >= 4 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
+        // return success && data.length == 32 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
         bytes4 selector = IERC1271.isValidSignature.selector;
         assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
             let ptr := mload(0x40)

--- a/contracts/libraries/ECDSA.sol
+++ b/contracts/libraries/ECDSA.sol
@@ -297,7 +297,7 @@ library ECDSA {
         bytes32 vs
     ) internal view returns (bool success) {
         // (bool success, bytes memory data) = signer.staticcall(abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, abi.encodePacked(r, vs)));
-        // return success && data.length >= 4 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
+        // return success && data.length == 32 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
         bytes4 selector = IERC1271.isValidSignature.selector;
         assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
             let ptr := mload(0x40)
@@ -329,7 +329,7 @@ library ECDSA {
         bytes32 vs
     ) internal view returns (bool success) {
         // (bool success, bytes memory data) = signer.staticcall(abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, abi.encodePacked(r, vs & ~uint256(1 << 255), uint8(vs >> 255))));
-        // return success && data.length >= 4 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
+        // return success && data.length == 32 && abi.decode(data, (bytes4)) == IERC1271.isValidSignature.selector;
         bytes4 selector = IERC1271.isValidSignature.selector;
         assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
             let ptr := mload(0x40)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
- This makes sure the commented solidity code accurately reflects what is being done in assembly.