### PR TITLE
[SC-1242] skipIfAlreadyDeployed in deploy method via create3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -254,6 +254,7 @@ describe('utils', function () {
                 constructorArgs: [tokenName, 'STM'],
                 deployments,
                 skipVerify: true,
+                skipIfAlreadyDeployed: false,
             });
             const token2 = await deployAndGetContractWithCreate3({
                 create3Deployer: await create3Deployer.getAddress(),
@@ -262,6 +263,7 @@ describe('utils', function () {
                 constructorArgs: [tokenName, 'STM'],
                 deployments,
                 skipVerify: true,
+                skipIfAlreadyDeployed: true,
             });
             expect(await token1.getAddress()).to.be.eq(await token2.getAddress());
         }); //.timeout(200000);  If this test needs to be run on a test chain, the timeout should be increased

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -231,6 +231,7 @@ describe('utils', function () {
                 constructorArgs: [tokenName, 'STM'],
                 deployments,
                 skipVerify: true,
+                skipIfAlreadyDeployed: false,
             });
             expect(await create3Deployer.addressOf(salt)).to.be.eq(await token.getAddress());
             expect(await token.name()).to.be.eq(tokenName);
@@ -240,6 +241,29 @@ describe('utils', function () {
                 abi: (await hre.artifacts.readArtifact('TokenMock')).abi,
                 bytecode: (await hre.artifacts.readArtifact('TokenMock')).bytecode,
             });
+        }); //.timeout(200000);  If this test needs to be run on a test chain, the timeout should be increased
+
+        it('should skip if set skipIfAlreadyDeployed', async function () {
+            const create3Deployer = await deployContract('Create3Mock') as Create3Mock;
+            const salt = ethers.keccak256(ethers.toUtf8Bytes('SOME SALT HERE'));
+            const tokenName = 'SomeToken';
+            const token1 = await deployAndGetContractWithCreate3({
+                create3Deployer: await create3Deployer.getAddress(),
+                salt,
+                contractName: 'TokenMock',
+                constructorArgs: [tokenName, 'STM'],
+                deployments,
+                skipVerify: true,
+            });
+            const token2 = await deployAndGetContractWithCreate3({
+                create3Deployer: await create3Deployer.getAddress(),
+                salt,
+                contractName: 'TokenMock',
+                constructorArgs: [tokenName, 'STM'],
+                deployments,
+                skipVerify: true,
+            });
+            expect(await token1.getAddress()).to.be.eq(await token2.getAddress());
         }); //.timeout(200000);  If this test needs to be run on a test chain, the timeout should be increased
     });
 
@@ -255,6 +279,7 @@ describe('utils', function () {
                 constructorArgs: [tokenName, 'STM'],
                 deployments,
                 skipVerify: true,
+                skipIfAlreadyDeployed: false,
             });
 
             await saveContractWithCreate3Deployment(


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):
It's good enough readable and compact check.

#### Dynamic Code Analysis (external APIs, interaction flows):
By default the check is switched on to protect developer from prevent unnecessary redeployment of already deployed contracts. Allows to customize this setting status as needed.

#### Efficiency (gas costs, computational complexity, memory requirements):
No impact on gas costs and computational complexity.

#### Opinion, trade-offs and other thoughts (optional):
This addition is a straightforward and effective way to enhance deployment logic, with minimal trade-offs. It ensures that resources are used more efficiently without adding significant complexity to the codebase.
