### PR TITLE
[SC-1394] Fix avax forking issue

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -81,6 +81,14 @@ export class Networks {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 saveDeployments: saveHardhatDeployments,
+                chains: {
+                    43114: { // TODO: remove after hardhat fix issue since 2.22.3, https://github.com/NomicFoundation/hardhat/pull/6170
+                        hardforkHistory: {
+                            shanghai: 11404279,
+                            cancun: 41263126,
+                        },
+                    },
+                },
             };
             if (forkingAccounts) {
                 this.networks.hardhat!.accounts = forkingAccounts;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
Added a temporary solution by manually specifying the hardforkHistory property in Hardhat configuration to fix forking issue for Avalanche networks (the same as https://github.com/NomicFoundation/hardhat/issues/5511) until a [fix](https://github.com/NomicFoundation/hardhat/pull/6170) is implemented in Hardhat.

#### Static Code Analysis (readability, compactness):
- The solution is straightforward and does not introduce significant complexity.
- The added configuration is clear and maintains code readability.

#### Dynamic Code Analysis (external APIs, interaction flows):
- The fix relies on manually estimated block numbers based on timestamps from the blog:
   - ACP-24 (Shanghai): [December 22nd, 2022, at 6:42:29 AM UTC](https://www.avax.network/blog/durango-avalanche-warp-messaging-comes-to-the-evm)
   - ACP-131 (Cancun): [December 16th, 2024, at 5 PM UTC](https://www.avax.network/blog/etna-enhancing-the-sovereignty-of-avalanche-l1-networks)
- Forking functionality now works as expected with Hardhat versions >=2.22.3.

#### Efficiency (gas costs, computational complexity, memory requirements):
- No additional computational overhead introduced, as the changes only affect configuration.
- The impact is limited to the forking environment, with no runtime performance issues.

#### Opinion, trade-offs and other thoughts (optional):
- This is a temporary workaround until Hardhat provides an official solution.
- If incorrect block numbers were used, feedback and corrections are welcome.