### PR TITLE
[SC-1426] Permit2 with different address

### DIFF
--- a/contracts/tests/mocks/SafeERC20Helper.sol
+++ b/contracts/tests/mocks/SafeERC20Helper.sol
@@ -208,7 +208,7 @@ contract SafeERC20Wrapper {
         _token.safeTransferFrom(address(0), address(0), 0);
     }
 
-    function transferFromUniversal(bool permit2) external {
+    function transferFromUniversal(address permit2) external {
         _token.safeTransferFromUniversal(address(0), address(0), 0, permit2);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.3.2",
+  "version": "7.0.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/test/Permitable.test.ts
+++ b/test/Permitable.test.ts
@@ -120,7 +120,6 @@ describe('Permitable', function () {
         const permitContract = await permit2Contract();
         const permit = await getPermit2(signer1, await daiLikePermitMock.getAddress(), chainId, signer2.address, constants.MAX_UINT128);
         await permitableMock.mockPermit(daiLikePermitMock, permit);
-
         const allowance = await permitContract.allowance(signer1, daiLikePermitMock, signer2);
         expect(allowance.amount).to.equal(constants.MAX_UINT128);
         expect(allowance.nonce).to.equal(1);

--- a/test/contracts/SafestERC20.test.ts
+++ b/test/contracts/SafestERC20.test.ts
@@ -414,12 +414,12 @@ describe('SafeERC20', function () {
             const { permit2Mock } = await deployPermit2Mock();
             const code = await ethers.provider.getCode(permit2Mock);
             await ethers.provider.send('hardhat_setCode', [PERMIT2_ADDRESS, code]);
-            await wrapper.transferFromUniversal(true);
+            await wrapper.transferFromUniversal(PERMIT2_ADDRESS);
         });
 
         it("doesn't revert on transferFromUniversal, no permit2", async function () {
             const { wrapper } = await loadFixture(fixture);
-            await wrapper.transferFromUniversal(false);
+            await wrapper.transferFromUniversal(constants.ZERO_ADDRESS);
         });
 
         describe('approvals', function () {


### PR DESCRIPTION
Added support for passing the `Permit2` contract address to accommodate networks with different the contract addresses, such as zkSync.

#### Static Code Analysis (readability, compactness):
Parameterizing the address improves contract flexibility.

#### Dynamic Code Analysis (external APIs, interaction flows):
- Ensures compatibility with networks where the `Permit2` address differs.
- Enables the use of a custom `Permit2` contract.

#### Efficiency (gas costs, computational complexity, memory requirements):
Slight increase in gas costs due to storing the address and calculate it from data.

#### Opinion, trade-offs and other thoughts (optional):
Enhances multi-chain support with minimal changes.
