### PR TITLE
[SC-1426] Permit2 for zksync

### DIFF
--- a/contracts/libraries/SafeERC20.sol
+++ b/contracts/libraries/SafeERC20.sol
@@ -507,9 +507,6 @@ library SafeERC20 {
             case 260 { // zksync fork network
                 permit2 := _PERMIT2_ZKSYNC
             }
-            case 270 { // zksync local network
-                permit2 := _PERMIT2_ZKSYNC
-            }
             default {
                 permit2 := _PERMIT2
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
Added helper method `getPermit2Address` to avoid breaking changes by selecting the appropriate constant based on chainId for zkSync and other networks.

#### Static Code Analysis (readability, compactness):
Improves flexibility without modifying existing logic.

#### Dynamic Code Analysis (external APIs, interaction flows):
Ensures correct `Permit2` contract address selection per supported network.

#### Efficiency (gas costs, computational complexity, memory requirements):
Minimal gas overhead with conditional logic.

#### Opinion, trade-offs and other thoughts (optional):
- Maintains backward compatibility while adding multi-chain support.
- Easy to add different custom networks in the future.
