### PR TITLE
[SC-1479] Normalize test accounts to empty code state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,6 +3,7 @@ import {
     timeIncreaseTo, fixSignature, signMessage, trackReceivedTokenAndTx,
     countInstructions, deployContract, deployAndGetContract, deployContractFromBytecode,
     getEthPrice, deployAndGetContractWithCreate3, saveContractWithCreate3Deployment,
+    getAccountsWithCode,
 } from '../src/utils';
 import { expect } from '../src/expect';
 import hre, { deployments, ethers } from 'hardhat';
@@ -309,6 +310,31 @@ describe('utils', function () {
 
         it('should throw error with incorrect token symbol', async function () {
             await expect(getEthPrice('INVALID_SYMBOL')).to.be.rejectedWith('Failed to parse price from Coinbase API');
+        });
+    });
+
+    describe('getAccountsWithCode', function () {
+        it('should return accounts without bytecode by default', async function () {
+            const accounts = await getAccountsWithCode();
+            for (let i = 0; i < 10; i++) {
+                expect(await ethers.provider.getCode(accounts[i].address)).to.be.eq('0x');
+            }
+        });
+
+        it('should return accounts with the same specific bytecode', async function () {
+            const specificBytecode = '0x123456789a';
+            const accounts = await getAccountsWithCode(specificBytecode);
+            for (let i = 0; i < 10; i++) {
+                expect(await ethers.provider.getCode(accounts[i].address)).to.be.eq(specificBytecode);
+            }
+        });
+
+        it('should return specific accounts with specific bytecode', async function () {
+            const specificBytecodes = [, '0x1234',, '0x5678']; // eslint-disable-line no-sparse-arrays
+            const accounts = await getAccountsWithCode([, '0x1234',, '0x5678']); // eslint-disable-line no-sparse-arrays
+            for (let i = 0; i < 10; i++) {
+                expect(await ethers.provider.getCode(accounts[i].address)).to.be.eq(specificBytecodes[i] ? specificBytecodes[i] : '0x');
+            }
         });
     });
 });


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):
- Added `getAccountsWithCode()` utility for reuse across tests
- Simplifies setup logic and reduces code duplication

#### Dynamic Code Analysis (external APIs, interaction flows):
- Ensures test accounts are in a clean state by resetting code to '0x'
- Avoids issues with EIP-7702 forwarding contracts on default accounts
- Supports setting custom bytecode per account when needed

#### Efficiency (gas costs, computational complexity, memory requirements):
- Runs only in test environments, no impact on production
- Negligible overhead in test setup

#### Opinion, trade-offs and other thoughts (optional):
- Might generalize further if more bytecode cases appear