### PR TITLE
[SC-1504] Make `.env` loading optional with `autoLoadEnv` constructor flag

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -4,6 +4,18 @@ import { HardhatNetworkAccountsUserConfig, Network, NetworksUserConfig } from 'h
 
 /**
  * @category Hardhat-Setup
+ * Loads environment variables into process.env using the dotenv package.
+ * By default, loads variables from a `.env` file in the project root.
+ * You can provide custom options (e.g. a different path or encoding) via the `options` parameter.
+ * @param options Optional configuration object for dotenv (e.g. `{ path: '.env.local' }`).
+ * @see https://github.com/motdotla/dotenv#config
+ */
+export function loadEnv(options?: dotenv.DotenvConfigOptions): void {
+    dotenv.config(options);
+}
+
+/**
+ * @category Hardhat-Setup
  * Configuration type for managing Etherscan integration in Hardhat setups.
  * @param apiKey Dictionary of API keys for accessing Etherscan, indexed by network name.
  * @param customChains Array of custom blockchain network configurations.
@@ -72,8 +84,16 @@ export class Networks {
     networks: NetworksUserConfig = {};
     etherscan: Etherscan = { apiKey: {}, customChains: [] };
 
-    constructor(useHardhat: boolean = true, forkingNetworkName?: string, saveHardhatDeployments: boolean = false, forkingAccounts?: HardhatNetworkAccountsUserConfig) {
-        dotenv.config();
+    constructor(
+        useHardhat: boolean = true,
+        forkingNetworkName?: string,
+        saveHardhatDeployments: boolean = false,
+        forkingAccounts?: HardhatNetworkAccountsUserConfig,
+        autoLoadEnv: boolean = true
+    ) {
+        if (autoLoadEnv) {
+            loadEnv();
+        }
 
         if (useHardhat || forkingNetworkName) {
             this.networks.hardhat = {
@@ -88,7 +108,12 @@ export class Networks {
         }
 
         if (forkingNetworkName) {
-            const { url, authKeyHttpHeader } = parseRpcEnv(process.env[`${forkingNetworkName.toUpperCase()}_RPC_URL`] || '');
+            const forkRpcKey = `${forkingNetworkName.toUpperCase()}_RPC_URL`;
+            const forkRpcEnv = process.env[forkRpcKey];
+            if (!forkRpcEnv) {
+                throw new Error(`Missing required environment variable '${forkRpcKey}'. Did you forget to call loadEnv() or set autoLoadEnv to true?`);
+            }
+            const { url, authKeyHttpHeader } = parseRpcEnv(forkRpcEnv || '');
             this.networks.hardhat!.forking = {
                 url,
                 httpHeaders: authKeyHttpHeader ? { 'auth-key': authKeyHttpHeader } : undefined,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):
- Introduced an `autoLoadEnv` flag in the `Networks` constructor to control whether environment variables should be automatically loaded via `dotenv.config()`. 
- Added a `loadEnv()` utility function that loads environment variables, by default from `.env`, but accepts standard `dotenv.config` options (e.g., custom path or encoding). 

These changes remove hidden side effects, improve clarity, and preserve backward compatibility.

#### Dynamic Code Analysis (external APIs, interaction flows):
Previously, environment variables were always loaded implicitly during `Networks` instantiation, which could lead to issues if `process.env` was accessed before that (e.g., in `hardhat.config.ts`). The new approach allows developers to load environment variables explicitly using `loadEnv(options?)` at the appropriate point in the setup flow.

#### Efficiency (gas costs, computational complexity, memory requirements):
No impact. The change only affects how environment variables are loaded during setup and does not impact runtime or on-chain behavior.

#### Opinion, trade-offs and other thoughts (optional):
This change slightly increases the API surface but improves flexibility and makes environment handling explicit and predictable. It aligns with library design best practices by avoiding implicit side effects and supporting more advanced `dotenv` usage via options.
