### PR TITLE
Register `zksync` network to use it without zksolc

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -165,7 +165,8 @@ export class Networks {
         this.registerCustom('linea', 59144, process.env.LINEA_RPC_URL, process.env.LINEA_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.lineascan.build/api', 'https://lineascan.build/', 'london');
         this.registerCustom('sonic', 146, process.env.SONIC_RPC_URL, process.env.SONIC_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.sonicscan.org/api', 'https://sonicscan.org/', 'shanghai');
         this.registerCustom('unichain', 130, process.env.UNICHAIN_RPC_URL, process.env.UNICHAIN_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.uniscan.xyz/api', 'https://uniscan.xyz/', 'shanghai');
-        this.register('zksync', 324, process.env.ZKSYNC_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, 'zksyncmainnet', etherscanApiKey, 'paris', 'mainnet');
+        this.registerCustom('zksync', 324, process.env.ZKSYNC_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.zksync.network/api', 'https://era.zksync.network/', 'paris');
+        this.register('zksync-zkevm', 324, process.env.ZKSYNC_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, 'zksyncmainnet', etherscanApiKey, 'paris', 'mainnet');
         this.register('zksyncTest', 300, process.env.ZKSYNC_TEST_RPC_URL, process.env.ZKSYNC_TEST_PRIVATE_KEY || privateKey, 'zksyncsepolia', etherscanApiKey, 'paris', 'sepolia');
         // For 'zksyncFork' network you should use zksync fork node: https://github.com/matter-labs/era-test-node
         this.register('zksyncFork', 260, process.env.ZKSYNC_FORK_RPC_URL, process.env.ZKSYNC_FORK_PRIVATE_KEY || privateKey, 'zksyncfork', 'none', 'paris', process.env.ZKSYNC_LOCAL_ETH_NETWORK || 'mainnet');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.7.1",
+  "version": "6.8.0",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
#### Static Code Analysis (readability, compactness):
- Rename `zksync` to `zksync-zkevm` (legacy zksolc).
- Added `zksync` (native EVM, no zksolc).

#### Dynamic Code Analysis (external APIs, interaction flows):
Deployments on `zksync` now use standard EVM toolchain. Any scripts or CI pipelines relying on the old `zksync` setup must be updated to target `zksync-zkevm` instead.

#### Efficiency (gas costs, computational complexity, memory requirements):
See gas or runtime impact performance [here](https://x.com/_weidai/status/1907509415546413365). Change affects compilation/deployment flow.

#### Opinion, trade-offs and other thoughts (optional):
This is a **breaking change**: existing code that uses `zksync` network will need to be updated depending on whether native EVM or zksolc-based flow is required.