### PR TITLE
Revert accidental direct push to master

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -173,9 +173,8 @@ export class Networks {
         this.register('zksyncLocal', 270, process.env.ZKSYNC_LOCAL_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, 'zksynclocal', 'none', 'paris', process.env.ZKSYNC_LOCAL_ETH_NETWORK);
         this.registerCustom('cronos', 25, process.env.CRONOS_RPC_URL, process.env.CRONOS_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/mainnet/api/v2', 'https://explorer.cronos.com/', 'shanghai');
         this.registerCustom('cronosTest', 338, process.env.CRONOS_TEST_RPC_URL, process.env.CRONOS_TEST_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/testnet/api/v2', 'https://explorer.cronos.org/testnet', 'shanghai');
-        this.registerCustom('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=143', 'https://monadscan.com/', 'cancun');
-        this.registerCustom('hyperevm', 999, process.env.HYPEREVM_RPC_URL, process.env.HYPEREVM_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=999', 'https://hyperevmscan.com/', 'cancun');
         this.register('robinhood', 4663, process.env.ROBINHOOD_RPC_URL, process.env.ROBINHOOD_PRIVATE_KEY || privateKey, 'robinhood', etherscanApiKey);
+        this.register('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, 'monad', etherscanApiKey);
         /* eslint-enable max-len */
         return { networks: this.networks, etherscan: this.etherscan };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.9.12",
+  "version": "6.9.11",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
Commits 786dbb9 (`add hyperevm`) and 85a1f06 (`bump version`) were pushed directly to `master` by mistake, bypassing review. This reverts both, restoring `master` to the state it had after #267.

The changes themselves are not being dropped — they come back through #269 (`chains/hyperevm`), which contains the same two commits rebased onto the pre-push base so they can be reviewed normally.

Merge this one first, then #269.

#### Static Code Analysis (readability, compactness):
Pure revert, no hand-written changes: `hardhat-setup/networks.ts` loses the hyperEVM entry and restores the previous `monad` registration, `package.json` returns to 6.9.11.

#### Dynamic Code Analysis (external APIs, interaction flows):
No contract code touched. The hyperEVM RPC config is removed, so nothing can resolve that network until #269 lands.

#### Efficiency (gas costs, computational complexity, memory requirements):
Not applicable — no Solidity changes.

#### Opinion, trade-offs and other thoughts (optional):
Revert-then-reapply was chosen over force-pushing `master`, so the published history stays intact for anyone who already fetched it. The cost is two extra commits in the log.