### PR TITLE
Add hyperEVM network, switch monad to registerCustom

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -173,8 +173,9 @@ export class Networks {
         this.register('zksyncLocal', 270, process.env.ZKSYNC_LOCAL_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, 'zksynclocal', 'none', 'paris', process.env.ZKSYNC_LOCAL_ETH_NETWORK);
         this.registerCustom('cronos', 25, process.env.CRONOS_RPC_URL, process.env.CRONOS_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/mainnet/api/v2', 'https://explorer.cronos.com/', 'shanghai');
         this.registerCustom('cronosTest', 338, process.env.CRONOS_TEST_RPC_URL, process.env.CRONOS_TEST_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/testnet/api/v2', 'https://explorer.cronos.org/testnet', 'shanghai');
+        this.registerCustom('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=143', 'https://monadscan.com/', 'cancun');
+        this.registerCustom('hyperevm', 999, process.env.HYPEREVM_RPC_URL, process.env.HYPEREVM_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=999', 'https://hyperevmscan.com/', 'cancun');
         this.register('robinhood', 4663, process.env.ROBINHOOD_RPC_URL, process.env.ROBINHOOD_PRIVATE_KEY || privateKey, 'robinhood', etherscanApiKey);
-        this.register('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, 'monad', etherscanApiKey);
         /* eslint-enable max-len */
         return { networks: this.networks, etherscan: this.etherscan };
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.9.11",
+  "version": "6.9.12",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
Adds hyperEVM (chain id 999) to `Networks` and changes `monad` (chain id 143) from `register` to `registerCustom`, so both go through the Etherscan v2 multichain API with explicit explorer URLs (`hyperevmscan.com`, `monadscan.com`) and the `cancun` EVM version. Version bumped to 6.9.12.

These are the two commits that were accidentally pushed straight to `master`; they have been rebased onto the pre-push base so they can be reviewed here. #268 reverts them from `master` and should be merged first.

#### Static Code Analysis (readability, compactness):
Both networks now use the same `registerCustom` shape as the neighbouring cronos entries, so the block is more uniform than before. `monad` moves out of the plain `register` group.

#### Dynamic Code Analysis (external APIs, interaction flows):
Both entries depend on `HYPEREVM_RPC_URL` / `MONAD_RPC_URL` env vars and the shared Etherscan API key. Verification for monad now points at `api.etherscan.io/v2/api?chainid=143` rather than the named `monad` Etherscan preset — worth confirming that key has v2 access for both chains before relying on `verify`.

#### Efficiency (gas costs, computational complexity, memory requirements):
Not applicable — hardhat network config only, no Solidity changes.

#### Opinion, trade-offs and other thoughts (optional):
The monad change is a behaviour change bundled with a new-network addition; it was reviewed together here because both arrived in the same commit.

Made with [Cursor](https://cursor.com)