### PR TITLE
fix monad hardfork: cancun -> shanghai

### DIFF
--- a/hardhat-setup/networks.ts
+++ b/hardhat-setup/networks.ts
@@ -173,7 +173,7 @@ export class Networks {
         this.register('zksyncLocal', 270, process.env.ZKSYNC_LOCAL_RPC_URL, process.env.ZKSYNC_PRIVATE_KEY || privateKey, 'zksynclocal', 'none', 'paris', process.env.ZKSYNC_LOCAL_ETH_NETWORK);
         this.registerCustom('cronos', 25, process.env.CRONOS_RPC_URL, process.env.CRONOS_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/mainnet/api/v2', 'https://explorer.cronos.com/', 'shanghai');
         this.registerCustom('cronosTest', 338, process.env.CRONOS_TEST_RPC_URL, process.env.CRONOS_TEST_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://explorer-api.cronos.org/testnet/api/v2', 'https://explorer.cronos.org/testnet', 'shanghai');
-        this.registerCustom('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=143', 'https://monadscan.com/', 'cancun');
+        this.registerCustom('monad', 143, process.env.MONAD_RPC_URL, process.env.MONAD_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=143', 'https://monadscan.com/', 'shanghai');
         this.registerCustom('hyperevm', 999, process.env.HYPEREVM_RPC_URL, process.env.HYPEREVM_PRIVATE_KEY || privateKey, etherscanApiKey, 'https://api.etherscan.io/v2/api?chainid=999', 'https://hyperevmscan.com/', 'shanghai');
         this.register('robinhood', 4663, process.env.ROBINHOOD_RPC_URL, process.env.ROBINHOOD_PRIVATE_KEY || privateKey, 'robinhood', etherscanApiKey);
         /* eslint-enable max-len */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1inch/solidity-utils",
-  "version": "6.9.13",
+  "version": "6.9.14",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {


### PR DESCRIPTION
Sets the `monad` network (chainId 143) hardfork to `shanghai` instead of `cancun` in `hardhat-setup/networks.ts`, and bumps the package version to 6.9.14.

#### Static Code Analysis (readability, compactness):

One-line change to the `registerCustom('monad', ...)` call, consistent with the other chains registered with `shanghai`.

#### Dynamic Code Analysis (external APIs, interaction flows):

Affects the hardfork passed to the Hardhat network config for `monad` deployments and verification. No API surface change.

#### Efficiency (gas costs, computational complexity, memory requirements):

Not applicable.

#### Opinion, trade-offs and other thoughts (optional):

The 6.9.14 release also carries the unreleased GitHub Actions Node 24 fix already on `master` (8983078).

Made with [Cursor](https://cursor.com)