### PR TITLE
[PT1-864] Relax pragma

### DIFF
--- a/contracts/interfaces/IRescuable.sol
+++ b/contracts/interfaces/IRescuable.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/libraries/Calldata.sol
+++ b/contracts/libraries/Calldata.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 /**
  * @title Calldata

--- a/contracts/libraries/Calldata.sol
+++ b/contracts/libraries/Calldata.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 /**
  * @title Calldata

--- a/contracts/libraries/CalldataPtr.sol
+++ b/contracts/libraries/CalldataPtr.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 /**
  * @title CalldataPtr

--- a/contracts/libraries/CalldataPtr.sol
+++ b/contracts/libraries/CalldataPtr.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 /**
  * @title CalldataPtr

--- a/contracts/libraries/Transient.sol
+++ b/contracts/libraries/Transient.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 /**
  * @title tuint256

--- a/contracts/libraries/Transient.sol
+++ b/contracts/libraries/Transient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.24;
 
 /**
  * @title tuint256

--- a/contracts/libraries/TransientLock.sol
+++ b/contracts/libraries/TransientLock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { TransientLib, tuint256 } from "./Transient.sol";
 

--- a/contracts/libraries/TransientLockUnsafe.sol
+++ b/contracts/libraries/TransientLockUnsafe.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { TransientUnsafe, tuint256 } from "./TransientUnsafe.sol";
 import { TransientLock } from "./TransientLock.sol";

--- a/contracts/libraries/TransientUnsafe.sol
+++ b/contracts/libraries/TransientUnsafe.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { tuint256, taddress, tbytes32 } from "./Transient.sol";
 

--- a/contracts/libraries/TransientUnsafe.sol
+++ b/contracts/libraries/TransientUnsafe.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.24;
 
 import { tuint256, taddress, tbytes32 } from "./Transient.sol";
 

--- a/contracts/mixins/Multicall.sol
+++ b/contracts/mixins/Multicall.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 /**
  * @title Multicall

--- a/contracts/mixins/Multicall.sol
+++ b/contracts/mixins/Multicall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 /**
  * @title Multicall

--- a/contracts/mixins/ReentrancyGuard.sol
+++ b/contracts/mixins/ReentrancyGuard.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { TransientLock, TransientLockLib } from "../libraries/TransientLock.sol";
 

--- a/contracts/mixins/Rescuable.sol
+++ b/contracts/mixins/Rescuable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mixins/Rescuable.sol
+++ b/contracts/mixins/Rescuable.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/mixins/Simulator.sol
+++ b/contracts/mixins/Simulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 /**
  * @title Simulator

--- a/contracts/mixins/Simulator.sol
+++ b/contracts/mixins/Simulator.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 /**
  * @title Simulator

--- a/contracts/tests/mocks/CalldataMock.sol
+++ b/contracts/tests/mocks/CalldataMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/Calldata.sol";
 

--- a/contracts/tests/mocks/CalldataMock.sol
+++ b/contracts/tests/mocks/CalldataMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import "../../libraries/Calldata.sol";
 

--- a/contracts/tests/mocks/CalldataPtrMock.sol
+++ b/contracts/tests/mocks/CalldataPtrMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import "../../libraries/CalldataPtr.sol";
 

--- a/contracts/tests/mocks/CalldataPtrMock.sol
+++ b/contracts/tests/mocks/CalldataPtrMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/CalldataPtr.sol";
 

--- a/contracts/tests/mocks/MulticallMock.sol
+++ b/contracts/tests/mocks/MulticallMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../mixins/Multicall.sol";
 

--- a/contracts/tests/mocks/MulticallMock.sol
+++ b/contracts/tests/mocks/MulticallMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import "../../mixins/Multicall.sol";
 

--- a/contracts/tests/mocks/NoReceiveOwnerMock.sol
+++ b/contracts/tests/mocks/NoReceiveOwnerMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import { IRescuable } from "../../interfaces/IRescuable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/tests/mocks/NoReceiveOwnerMock.sol
+++ b/contracts/tests/mocks/NoReceiveOwnerMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { IRescuable } from "../../interfaces/IRescuable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/tests/mocks/ReentrancyGuardMock.sol
+++ b/contracts/tests/mocks/ReentrancyGuardMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable one-contract-per-file
-pragma solidity ^0.8.30;
+pragma solidity ^0.8.27;
 
 import "../../mixins/ReentrancyGuard.sol";
 

--- a/contracts/tests/mocks/RescuableMock.sol
+++ b/contracts/tests/mocks/RescuableMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import { Rescuable } from "../../mixins/Rescuable.sol";
 

--- a/contracts/tests/mocks/RescuableMock.sol
+++ b/contracts/tests/mocks/RescuableMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import { Rescuable } from "../../mixins/Rescuable.sol";
 

--- a/contracts/tests/mocks/SimulatorMock.sol
+++ b/contracts/tests/mocks/SimulatorMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable one-contract-per-file
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.0;
 
 import "../../mixins/Simulator.sol";
 

--- a/contracts/tests/mocks/SimulatorMock.sol
+++ b/contracts/tests/mocks/SimulatorMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable one-contract-per-file
-pragma solidity ^0.8.30;
+pragma solidity ^0.8.27;
 
 import "../../mixins/Simulator.sol";
 

--- a/contracts/tests/mocks/TransientLockMock.sol
+++ b/contracts/tests/mocks/TransientLockMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/TransientLock.sol";
 

--- a/contracts/tests/mocks/TransientLockNestedMock.sol
+++ b/contracts/tests/mocks/TransientLockNestedMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/TransientLock.sol";
 

--- a/contracts/tests/mocks/TransientLockUnsafeMock.sol
+++ b/contracts/tests/mocks/TransientLockUnsafeMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/TransientLockUnsafe.sol";
 

--- a/contracts/tests/mocks/TransientLockUnsafeNestedMock.sol
+++ b/contracts/tests/mocks/TransientLockUnsafeNestedMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/TransientLockUnsafe.sol";
 

--- a/contracts/tests/mocks/TransientMock.sol
+++ b/contracts/tests/mocks/TransientMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/Transient.sol";
 

--- a/contracts/tests/mocks/TransientMock.sol
+++ b/contracts/tests/mocks/TransientMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.24;
 
 import "../../libraries/Transient.sol";
 

--- a/contracts/tests/mocks/TransientUnsafeMock.sol
+++ b/contracts/tests/mocks/TransientUnsafeMock.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
+
+pragma solidity ^0.8.27;
 
 import "../../libraries/TransientUnsafe.sol";
 

--- a/contracts/tests/mocks/TransientUnsafeMock.sol
+++ b/contracts/tests/mocks/TransientUnsafeMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.24;
 
 import "../../libraries/TransientUnsafe.sol";
 

--- a/contracts/tests/mocks/WETH.sol
+++ b/contracts/tests/mocks/WETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity ^0.8.0;
 
 // solhint-disable custom-errors
 contract WETH {


### PR DESCRIPTION
Relax ^0.8.30 to ^0.8.27
Fix interfaces to have ^0.8.0

It would be nice to do a real revise of each file pragma and use the minimal or apply 0.8.4 / 0.8.27 rule

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compiler-version metadata only; no bytecode or behavior changes unless consumers compile with an older 0.8.x than previously allowed.
> 
> **Overview**
> **Relaxes Solidity compiler pragmas** across contracts, mixins, libraries, and test mocks so the package can compile on older 0.8.x toolchains instead of requiring `^0.8.30`.
> 
> Interfaces and general-purpose code (e.g. `IRescuable`, `Calldata`, `Multicall`, `Rescuable`, `Simulator`) move to **`^0.8.0`**. Transient-storage helpers stay at **`^0.8.24`** (`Transient`, `TransientUnsafe` and their mocks). Reentrancy / transient-lock code stays at **`^0.8.27`** (`ReentrancyGuard`, `TransientLock*`, related mocks). The test `WETH` mock is aligned from `^0.8.15` to **`^0.8.0`**.
> 
> No runtime logic, imports, or APIs change—only `pragma solidity` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee972ed5aea36b81f5f2191cb1c87087e7133cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->