### PR TITLE
[PT1-865] Allow calldata slice empty slice output

### DIFF
--- a/contracts/libraries/Calldata.sol
+++ b/contracts/libraries/Calldata.sol
@@ -67,7 +67,7 @@ library Calldata {
      * @return res The sliced calldata bytes from begin to the end.
      */
     function slice(bytes calldata calls, uint256 begin, bytes4 exception) internal pure returns (bytes calldata res) {
-        if (begin >= calls.length) {
+        if (begin > calls.length) {
             assembly ("memory-safe") {  // solhint-disable-line no-inline-assembly
                 mstore(0, exception)
                 revert(0, 4)

--- a/contracts/libraries/Calldata.sol
+++ b/contracts/libraries/Calldata.sol
@@ -25,6 +25,7 @@ library Calldata {
     /**
      * @dev Returns a slice of the calldata bytes from `begin` to `end` index with bounds checking.
      * Reverts with the provided exception selector if `end` exceeds the calldata length.
+     * Warning: Does not check `begin <= end` for gas efficiency.
      * @param calls The calldata bytes to slice.
      * @param begin The starting index of the slice.
      * @param end The ending index of the slice (exclusive).

--- a/test/contracts/Calldata.test.ts
+++ b/test/contracts/Calldata.test.ts
@@ -78,6 +78,12 @@ describe('Calldata', function () {
             expect(result).to.equal('0x101112131415161718191a1b1c1d1e1f');
         });
 
+        it('should return empty when begin equals length', async function () {
+            const { mock } = await loadFixture(deployCalldataMock);
+            const result = await mock.sliceToEndChecked(testData, 32);
+            expect(result).to.equal('0x');
+        });
+
         it('should revert when begin exceeds length', async function () {
             const { mock } = await loadFixture(deployCalldataMock);
             await expect(mock.sliceToEndChecked(testData, 33))


### PR DESCRIPTION
Relax if revert condition to allow `begin == length` case with zero-length slice as output + add corresponding test

```solidity
// General functions should not care if slicing in-middle ot the last data part 
function consume32(bytes calldata calls) returns (bytes calldata tail) {
  bytes32 data = calls[0:32];
  tail = calls.slice(32, Error.selector); // Would fail now for calls.length == 32
}
```

Added a warning for `begin <= end` is unchecked even in `slice(calls, begin, end, selector)` version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, intentional behavior change in a low-level slicing helper; only expands valid inputs to include zero-length tails with no security-sensitive logic touched.
> 
> **Overview**
> Relaxes bounds checking on **`Calldata.slice(calls, begin, exception)`** so **`begin == calls.length`** returns an **empty** calldata slice instead of reverting. The revert condition changes from **`begin >= calls.length`** to **`begin > calls.length`**, matching the unchecked slice helpers and typical “consume rest of buffer” patterns (e.g. tail after reading exactly `calls.length` bytes).
> 
> Also documents that the **`begin`–`end`** overload with exception **does not validate `begin <= end`** (gas tradeoff). Tests add coverage for the **`begin == length`** empty result; **`begin > length`** still reverts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a4b265c0d24ac3b2a5def6d945b8201fb13278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->