### PR TITLE
[PT1-866] Add calldata parse library

### DIFF
--- a/contracts/libraries/CalldataParse.sol
+++ b/contracts/libraries/CalldataParse.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.27;
+
+/**
+ * @notice Intermediary type existing between `at()` and `as<T>()`.
+ * Not intended for direct use.
+ * @dev Eliminates need of `using CalldataParse for bytes32` in each file.
+ */
+type CalldataWord is bytes32;
+using CalldataParse for CalldataWord global;
+
+/**
+ * @title CalldataParse
+ * @notice Library for efficient packed values parsing from calldata byte arrays.
+ * Warning: Does not perform array bounds checking for gas efficiency.
+ * @dev Resolve function (`as<T>()`) extracts left-aligned packed bytes as value of type `T`.
+ * @dev Parsing examples: `calls.at(0).asU16()`, `calls.at(2).asAddress()`, `calls.at(22).asBool(0)`.
+ */
+library CalldataParse {
+    /**
+     * @notice Loads a 32-byte word from calldata byte array at a byte offset.
+     * @param calls Calldata bytes to read from.
+     * @param shift Byte offset in `calls` array.
+     * @return res Loaded word.
+     */
+    function at(bytes calldata calls, uint256 shift) internal pure returns (CalldataWord res) {
+        assembly ("memory-safe") { // solhint-disable-line no-inline-assembly
+            res := calldataload(add(calls.offset, shift))
+        }
+    }
+
+    /**
+     * @notice Reads a bit from a calldata word.
+     * @param word Word to read from.
+     * @param bit Zero-based bit position, counted from the most-significant (left) bit.
+     * @return Whether the specified bit is set.
+     */
+    function asBool(CalldataWord word, uint8 bit) internal pure returns (bool) {
+        return (CalldataWord.unwrap(word) << bit) & 0x8000000000000000000000000000000000000000000000000000000000000000 != 0;
+    }
+
+    function asAddress(CalldataWord word) internal pure returns (address) { return address(bytes20(CalldataWord.unwrap(word))); }
+
+    function asU8(CalldataWord word) internal pure returns (uint8) { return uint8(bytes1(CalldataWord.unwrap(word))); }
+    function asU16(CalldataWord word) internal pure returns (uint16) { return uint16(bytes2(CalldataWord.unwrap(word))); }
+    function asU24(CalldataWord word) internal pure returns (uint24) { return uint24(bytes3(CalldataWord.unwrap(word))); }
+    function asU32(CalldataWord word) internal pure returns (uint32) { return uint32(bytes4(CalldataWord.unwrap(word))); }
+    function asU40(CalldataWord word) internal pure returns (uint40) { return uint40(bytes5(CalldataWord.unwrap(word))); }
+    function asU48(CalldataWord word) internal pure returns (uint48) { return uint48(bytes6(CalldataWord.unwrap(word))); }
+    function asU56(CalldataWord word) internal pure returns (uint56) { return uint56(bytes7(CalldataWord.unwrap(word))); }
+    function asU64(CalldataWord word) internal pure returns (uint64) { return uint64(bytes8(CalldataWord.unwrap(word))); }
+    function asU72(CalldataWord word) internal pure returns (uint72) { return uint72(bytes9(CalldataWord.unwrap(word))); }
+    function asU80(CalldataWord word) internal pure returns (uint80) { return uint80(bytes10(CalldataWord.unwrap(word))); }
+    function asU88(CalldataWord word) internal pure returns (uint88) { return uint88(bytes11(CalldataWord.unwrap(word))); }
+    function asU96(CalldataWord word) internal pure returns (uint96) { return uint96(bytes12(CalldataWord.unwrap(word))); }
+    function asU104(CalldataWord word) internal pure returns (uint104) { return uint104(bytes13(CalldataWord.unwrap(word))); }
+    function asU112(CalldataWord word) internal pure returns (uint112) { return uint112(bytes14(CalldataWord.unwrap(word))); }
+    function asU120(CalldataWord word) internal pure returns (uint120) { return uint120(bytes15(CalldataWord.unwrap(word))); }
+    function asU128(CalldataWord word) internal pure returns (uint128) { return uint128(bytes16(CalldataWord.unwrap(word))); }
+    function asU136(CalldataWord word) internal pure returns (uint136) { return uint136(bytes17(CalldataWord.unwrap(word))); }
+    function asU144(CalldataWord word) internal pure returns (uint144) { return uint144(bytes18(CalldataWord.unwrap(word))); }
+    function asU152(CalldataWord word) internal pure returns (uint152) { return uint152(bytes19(CalldataWord.unwrap(word))); }
+    function asU160(CalldataWord word) internal pure returns (uint160) { return uint160(bytes20(CalldataWord.unwrap(word))); }
+    function asU168(CalldataWord word) internal pure returns (uint168) { return uint168(bytes21(CalldataWord.unwrap(word))); }
+    function asU176(CalldataWord word) internal pure returns (uint176) { return uint176(bytes22(CalldataWord.unwrap(word))); }
+    function asU184(CalldataWord word) internal pure returns (uint184) { return uint184(bytes23(CalldataWord.unwrap(word))); }
+    function asU192(CalldataWord word) internal pure returns (uint192) { return uint192(bytes24(CalldataWord.unwrap(word))); }
+    function asU200(CalldataWord word) internal pure returns (uint200) { return uint200(bytes25(CalldataWord.unwrap(word))); }
+    function asU208(CalldataWord word) internal pure returns (uint208) { return uint208(bytes26(CalldataWord.unwrap(word))); }
+    function asU216(CalldataWord word) internal pure returns (uint216) { return uint216(bytes27(CalldataWord.unwrap(word))); }
+    function asU224(CalldataWord word) internal pure returns (uint224) { return uint224(bytes28(CalldataWord.unwrap(word))); }
+    function asU232(CalldataWord word) internal pure returns (uint232) { return uint232(bytes29(CalldataWord.unwrap(word))); }
+    function asU240(CalldataWord word) internal pure returns (uint240) { return uint240(bytes30(CalldataWord.unwrap(word))); }
+    function asU248(CalldataWord word) internal pure returns (uint248) { return uint248(bytes31(CalldataWord.unwrap(word))); }
+    function asU256(CalldataWord word) internal pure returns (uint256) { return uint256(bytes32(CalldataWord.unwrap(word))); }
+
+    function asBytes1(CalldataWord word) internal pure returns (bytes1) { return bytes1(CalldataWord.unwrap(word)); }
+    function asBytes2(CalldataWord word) internal pure returns (bytes2) { return bytes2(CalldataWord.unwrap(word)); }
+    function asBytes3(CalldataWord word) internal pure returns (bytes3) { return bytes3(CalldataWord.unwrap(word)); }
+    function asBytes4(CalldataWord word) internal pure returns (bytes4) { return bytes4(CalldataWord.unwrap(word)); }
+    function asBytes5(CalldataWord word) internal pure returns (bytes5) { return bytes5(CalldataWord.unwrap(word)); }
+    function asBytes6(CalldataWord word) internal pure returns (bytes6) { return bytes6(CalldataWord.unwrap(word)); }
+    function asBytes7(CalldataWord word) internal pure returns (bytes7) { return bytes7(CalldataWord.unwrap(word)); }
+    function asBytes8(CalldataWord word) internal pure returns (bytes8) { return bytes8(CalldataWord.unwrap(word)); }
+    function asBytes9(CalldataWord word) internal pure returns (bytes9) { return bytes9(CalldataWord.unwrap(word)); }
+    function asBytes10(CalldataWord word) internal pure returns (bytes10) { return bytes10(CalldataWord.unwrap(word)); }
+    function asBytes11(CalldataWord word) internal pure returns (bytes11) { return bytes11(CalldataWord.unwrap(word)); }
+    function asBytes12(CalldataWord word) internal pure returns (bytes12) { return bytes12(CalldataWord.unwrap(word)); }
+    function asBytes13(CalldataWord word) internal pure returns (bytes13) { return bytes13(CalldataWord.unwrap(word)); }
+    function asBytes14(CalldataWord word) internal pure returns (bytes14) { return bytes14(CalldataWord.unwrap(word)); }
+    function asBytes15(CalldataWord word) internal pure returns (bytes15) { return bytes15(CalldataWord.unwrap(word)); }
+    function asBytes16(CalldataWord word) internal pure returns (bytes16) { return bytes16(CalldataWord.unwrap(word)); }
+    function asBytes17(CalldataWord word) internal pure returns (bytes17) { return bytes17(CalldataWord.unwrap(word)); }
+    function asBytes18(CalldataWord word) internal pure returns (bytes18) { return bytes18(CalldataWord.unwrap(word)); }
+    function asBytes19(CalldataWord word) internal pure returns (bytes19) { return bytes19(CalldataWord.unwrap(word)); }
+    function asBytes20(CalldataWord word) internal pure returns (bytes20) { return bytes20(CalldataWord.unwrap(word)); }
+    function asBytes21(CalldataWord word) internal pure returns (bytes21) { return bytes21(CalldataWord.unwrap(word)); }
+    function asBytes22(CalldataWord word) internal pure returns (bytes22) { return bytes22(CalldataWord.unwrap(word)); }
+    function asBytes23(CalldataWord word) internal pure returns (bytes23) { return bytes23(CalldataWord.unwrap(word)); }
+    function asBytes24(CalldataWord word) internal pure returns (bytes24) { return bytes24(CalldataWord.unwrap(word)); }
+    function asBytes25(CalldataWord word) internal pure returns (bytes25) { return bytes25(CalldataWord.unwrap(word)); }
+    function asBytes26(CalldataWord word) internal pure returns (bytes26) { return bytes26(CalldataWord.unwrap(word)); }
+    function asBytes27(CalldataWord word) internal pure returns (bytes27) { return bytes27(CalldataWord.unwrap(word)); }
+    function asBytes28(CalldataWord word) internal pure returns (bytes28) { return bytes28(CalldataWord.unwrap(word)); }
+    function asBytes29(CalldataWord word) internal pure returns (bytes29) { return bytes29(CalldataWord.unwrap(word)); }
+    function asBytes30(CalldataWord word) internal pure returns (bytes30) { return bytes30(CalldataWord.unwrap(word)); }
+    function asBytes31(CalldataWord word) internal pure returns (bytes31) { return bytes31(CalldataWord.unwrap(word)); }
+    function asBytes32(CalldataWord word) internal pure returns (bytes32) { return bytes32(CalldataWord.unwrap(word)); }
+}

--- a/contracts/libraries/CalldataSlice.sol
+++ b/contracts/libraries/CalldataSlice.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.30;
 
 /**
- * @title Calldata
+ * @title CalldataSlice
  * @dev Library for efficient slicing of calldata byte arrays without memory copying.
  * Provides gas-optimized operations for extracting portions of calldata directly.
  */
-library Calldata {
+library CalldataSlice {
     /**
      * @dev Returns a slice of the calldata bytes from `begin` to `end` index.
      * Warning: Does not perform bounds checking for gas efficiency.

--- a/contracts/tests/mocks/CalldataParseMock.sol
+++ b/contracts/tests/mocks/CalldataParseMock.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import "../../libraries/CalldataParse.sol";
+
+contract CalldataParseMock {
+    using CalldataParse for bytes;
+
+    error InvalidSize();
+
+    function asBool(bytes calldata data, uint256 shift, uint8 bit) external pure returns (bool) {
+        return data.at(shift).asBool(bit);
+    }
+
+    function asAddress(bytes calldata data, uint256 shift) external pure returns (address) {
+        return data.at(shift).asAddress();
+    }
+
+    function asUintN(bytes calldata data, uint256 shift, uint256 n) external pure returns (uint256) {
+        CalldataWord word = data.at(shift);
+        if (n == 8) return word.asU8();
+        if (n == 16) return word.asU16();
+        if (n == 24) return word.asU24();
+        if (n == 32) return word.asU32();
+        if (n == 40) return word.asU40();
+        if (n == 48) return word.asU48();
+        if (n == 56) return word.asU56();
+        if (n == 64) return word.asU64();
+        if (n == 72) return word.asU72();
+        if (n == 80) return word.asU80();
+        if (n == 88) return word.asU88();
+        if (n == 96) return word.asU96();
+        if (n == 104) return word.asU104();
+        if (n == 112) return word.asU112();
+        if (n == 120) return word.asU120();
+        if (n == 128) return word.asU128();
+        if (n == 136) return word.asU136();
+        if (n == 144) return word.asU144();
+        if (n == 152) return word.asU152();
+        if (n == 160) return word.asU160();
+        if (n == 168) return word.asU168();
+        if (n == 176) return word.asU176();
+        if (n == 184) return word.asU184();
+        if (n == 192) return word.asU192();
+        if (n == 200) return word.asU200();
+        if (n == 208) return word.asU208();
+        if (n == 216) return word.asU216();
+        if (n == 224) return word.asU224();
+        if (n == 232) return word.asU232();
+        if (n == 240) return word.asU240();
+        if (n == 248) return word.asU248();
+        if (n == 256) return word.asU256();
+        revert InvalidSize();
+    }
+
+    function asBytesN(bytes calldata data, uint256 shift, uint256 n) external pure returns (bytes32) {
+        CalldataWord word = data.at(shift);
+        if (n == 1) return word.asBytes1();
+        if (n == 2) return word.asBytes2();
+        if (n == 3) return word.asBytes3();
+        if (n == 4) return word.asBytes4();
+        if (n == 5) return word.asBytes5();
+        if (n == 6) return word.asBytes6();
+        if (n == 7) return word.asBytes7();
+        if (n == 8) return word.asBytes8();
+        if (n == 9) return word.asBytes9();
+        if (n == 10) return word.asBytes10();
+        if (n == 11) return word.asBytes11();
+        if (n == 12) return word.asBytes12();
+        if (n == 13) return word.asBytes13();
+        if (n == 14) return word.asBytes14();
+        if (n == 15) return word.asBytes15();
+        if (n == 16) return word.asBytes16();
+        if (n == 17) return word.asBytes17();
+        if (n == 18) return word.asBytes18();
+        if (n == 19) return word.asBytes19();
+        if (n == 20) return word.asBytes20();
+        if (n == 21) return word.asBytes21();
+        if (n == 22) return word.asBytes22();
+        if (n == 23) return word.asBytes23();
+        if (n == 24) return word.asBytes24();
+        if (n == 25) return word.asBytes25();
+        if (n == 26) return word.asBytes26();
+        if (n == 27) return word.asBytes27();
+        if (n == 28) return word.asBytes28();
+        if (n == 29) return word.asBytes29();
+        if (n == 30) return word.asBytes30();
+        if (n == 31) return word.asBytes31();
+        if (n == 32) return word.asBytes32();
+        revert InvalidSize();
+    }
+}

--- a/contracts/tests/mocks/CalldataSliceMock.sol
+++ b/contracts/tests/mocks/CalldataSliceMock.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import "../../libraries/Calldata.sol";
+import "../../libraries/CalldataSlice.sol";
 
-contract CalldataMock {
+contract CalldataSliceMock {
     error TestError();
 
     function sliceWithBounds(bytes calldata data, uint256 begin, uint256 end) external pure returns (bytes calldata) {
-        return Calldata.slice(data, begin, end);
+        return CalldataSlice.slice(data, begin, end);
     }
 
     function sliceWithBoundsChecked(bytes calldata data, uint256 begin, uint256 end) external pure returns (bytes calldata) {
-        return Calldata.slice(data, begin, end, TestError.selector);
+        return CalldataSlice.slice(data, begin, end, TestError.selector);
     }
 
     function sliceToEnd(bytes calldata data, uint256 begin) external pure returns (bytes calldata) {
-        return Calldata.slice(data, begin);
+        return CalldataSlice.slice(data, begin);
     }
 
     function sliceToEndChecked(bytes calldata data, uint256 begin) external pure returns (bytes calldata) {
-        return Calldata.slice(data, begin, TestError.selector);
+        return CalldataSlice.slice(data, begin, TestError.selector);
     }
 }

--- a/test/contracts/CalldataParse.test.ts
+++ b/test/contracts/CalldataParse.test.ts
@@ -1,0 +1,159 @@
+import { expect } from '../../src/expect';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { ethers } from 'hardhat';
+
+describe('CalldataParse', function () {
+    const data = '0x10111213141516171819fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f';
+    const shift = 10;
+
+    async function deployCalldataParseMock() {
+        const CalldataParseMock = await ethers.getContractFactory('CalldataParseMock');
+        const mock = await CalldataParseMock.deploy();
+        return { mock };
+    }
+
+    describe('shift', function () {
+        it('should resolve zero shift', () => testShift(0, '0x10111213141516171819fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f'));
+        it('should resolve mid shift', () => testShift(shift, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536373839'));
+        it('should resolve max shift', () => testShift(16, '0x202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f'));
+
+        async function testShift(shift: number, expected: string) {
+            const { mock } = await loadFixture(deployCalldataParseMock);
+            expect(await mock.asBytesN(data, shift, 32)).to.equal(expected);
+        }
+    });
+
+    describe('asBool', function () {
+        it('should resolve bits from zero byte', async function () {
+            // 0xfa = 11111010
+            await testBool(0, true);
+            await testBool(1, true);
+            await testBool(2, true);
+            await testBool(3, true);
+            await testBool(4, true);
+            await testBool(5, false);
+            await testBool(6, true);
+            await testBool(7, false);
+        });
+
+        it('should resolve bits from mid byte', async function () {
+            // 0x2f = 00101111
+            await testBool(168, false);
+            await testBool(169, false);
+            await testBool(170, true);
+            await testBool(171, false);
+            await testBool(172, true);
+            await testBool(173, true);
+            await testBool(174, true);
+            await testBool(175, true);
+        });
+
+        it('should resolve bits from last byte', async function () {
+            // 0x39 = 00111001
+            await testBool(248, false);
+            await testBool(249, false);
+            await testBool(250, true);
+            await testBool(251, true);
+            await testBool(252, true);
+            await testBool(253, false);
+            await testBool(254, false);
+            await testBool(255, true);
+        });
+
+        async function testBool(bit: number, expected: boolean) {
+            const { mock } = await loadFixture(deployCalldataParseMock);
+            expect(await mock.asBool(data, shift, bit)).to.equal(expected);
+        }
+    });
+
+    describe('asAddress', function () {
+        it('should resolve address', async function () {
+            const { mock } = await loadFixture(deployCalldataParseMock);
+            expect(await mock.asAddress(data, shift)).to.equal(ethers.getAddress('0xfa1b1c1d1e1f202122232425262728292a2b2c2d'));
+        });
+    });
+
+    describe('asUintN', function () {
+        it('should resolve uintN', async function () {
+            await testUint(8,   '0x00000000000000000000000000000000000000000000000000000000000000fa');
+            await testUint(16,  '0x000000000000000000000000000000000000000000000000000000000000fa1b');
+            await testUint(24,  '0x0000000000000000000000000000000000000000000000000000000000fa1b1c');
+            await testUint(32,  '0x00000000000000000000000000000000000000000000000000000000fa1b1c1d');
+            await testUint(40,  '0x000000000000000000000000000000000000000000000000000000fa1b1c1d1e');
+            await testUint(48,  '0x0000000000000000000000000000000000000000000000000000fa1b1c1d1e1f');
+            await testUint(56,  '0x00000000000000000000000000000000000000000000000000fa1b1c1d1e1f20');
+            await testUint(64,  '0x000000000000000000000000000000000000000000000000fa1b1c1d1e1f2021');
+            await testUint(72,  '0x0000000000000000000000000000000000000000000000fa1b1c1d1e1f202122');
+            await testUint(80,  '0x00000000000000000000000000000000000000000000fa1b1c1d1e1f20212223');
+            await testUint(88,  '0x000000000000000000000000000000000000000000fa1b1c1d1e1f2021222324');
+            await testUint(96,  '0x0000000000000000000000000000000000000000fa1b1c1d1e1f202122232425');
+            await testUint(104, '0x00000000000000000000000000000000000000fa1b1c1d1e1f20212223242526');
+            await testUint(112, '0x000000000000000000000000000000000000fa1b1c1d1e1f2021222324252627');
+            await testUint(120, '0x0000000000000000000000000000000000fa1b1c1d1e1f202122232425262728');
+            await testUint(128, '0x00000000000000000000000000000000fa1b1c1d1e1f20212223242526272829');
+            await testUint(136, '0x000000000000000000000000000000fa1b1c1d1e1f202122232425262728292a');
+            await testUint(144, '0x0000000000000000000000000000fa1b1c1d1e1f202122232425262728292a2b');
+            await testUint(152, '0x00000000000000000000000000fa1b1c1d1e1f202122232425262728292a2b2c');
+            await testUint(160, '0x000000000000000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d');
+            await testUint(168, '0x0000000000000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e');
+            await testUint(176, '0x00000000000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f');
+            await testUint(184, '0x000000000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30');
+            await testUint(192, '0x0000000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031');
+            await testUint(200, '0x00000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132');
+            await testUint(208, '0x000000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233');
+            await testUint(216, '0x0000000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334');
+            await testUint(224, '0x00000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435');
+            await testUint(232, '0x000000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536');
+            await testUint(240, '0x0000fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f3031323334353637');
+            await testUint(248, '0x00fa1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738');
+            await testUint(256, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536373839');
+        });
+
+        async function testUint(n: number, expected: string) {
+            const { mock } = await loadFixture(deployCalldataParseMock);
+            expect(await mock.asUintN(data, shift, n)).to.equal(BigInt(expected));
+        }
+    });
+
+    describe('asBytesN', function () {
+        it('should resolve bytesN', async function () {
+            await testBytes(1,  '0xfa00000000000000000000000000000000000000000000000000000000000000');
+            await testBytes(2,  '0xfa1b000000000000000000000000000000000000000000000000000000000000');
+            await testBytes(3,  '0xfa1b1c0000000000000000000000000000000000000000000000000000000000');
+            await testBytes(4,  '0xfa1b1c1d00000000000000000000000000000000000000000000000000000000');
+            await testBytes(5,  '0xfa1b1c1d1e000000000000000000000000000000000000000000000000000000');
+            await testBytes(6,  '0xfa1b1c1d1e1f0000000000000000000000000000000000000000000000000000');
+            await testBytes(7,  '0xfa1b1c1d1e1f2000000000000000000000000000000000000000000000000000');
+            await testBytes(8,  '0xfa1b1c1d1e1f2021000000000000000000000000000000000000000000000000');
+            await testBytes(9,  '0xfa1b1c1d1e1f2021220000000000000000000000000000000000000000000000');
+            await testBytes(10, '0xfa1b1c1d1e1f2021222300000000000000000000000000000000000000000000');
+            await testBytes(11, '0xfa1b1c1d1e1f2021222324000000000000000000000000000000000000000000');
+            await testBytes(12, '0xfa1b1c1d1e1f2021222324250000000000000000000000000000000000000000');
+            await testBytes(13, '0xfa1b1c1d1e1f2021222324252600000000000000000000000000000000000000');
+            await testBytes(14, '0xfa1b1c1d1e1f2021222324252627000000000000000000000000000000000000');
+            await testBytes(15, '0xfa1b1c1d1e1f2021222324252627280000000000000000000000000000000000');
+            await testBytes(16, '0xfa1b1c1d1e1f2021222324252627282900000000000000000000000000000000');
+            await testBytes(17, '0xfa1b1c1d1e1f202122232425262728292a000000000000000000000000000000');
+            await testBytes(18, '0xfa1b1c1d1e1f202122232425262728292a2b0000000000000000000000000000');
+            await testBytes(19, '0xfa1b1c1d1e1f202122232425262728292a2b2c00000000000000000000000000');
+            await testBytes(20, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d000000000000000000000000');
+            await testBytes(21, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e0000000000000000000000');
+            await testBytes(22, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f00000000000000000000');
+            await testBytes(23, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30000000000000000000');
+            await testBytes(24, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30310000000000000000');
+            await testBytes(25, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313200000000000000');
+            await testBytes(26, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233000000000000');
+            await testBytes(27, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233340000000000');
+            await testBytes(28, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343500000000');
+            await testBytes(29, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536000000');
+            await testBytes(30, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536370000');
+            await testBytes(31, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536373800');
+            await testBytes(32, '0xfa1b1c1d1e1f202122232425262728292a2b2c2d2e2f30313233343536373839');
+        });
+
+        async function testBytes(n: number, expected: string) {
+            const { mock } = await loadFixture(deployCalldataParseMock);
+            expect(await mock.asBytesN(data, shift, n)).to.equal(expected);
+        }
+    });
+});

--- a/test/contracts/CalldataSlice.test.ts
+++ b/test/contracts/CalldataSlice.test.ts
@@ -2,12 +2,12 @@ import { expect } from '../../src/expect';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { ethers } from 'hardhat';
 
-describe('Calldata', function () {
+describe('CalldataSlice', function () {
     const testData = '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
 
     async function deployCalldataMock() {
-        const CalldataMock = await ethers.getContractFactory('CalldataMock');
-        const mock = await CalldataMock.deploy();
+        const CalldataSliceMock = await ethers.getContractFactory('CalldataSliceMock');
+        const mock = await CalldataSliceMock.deploy();
         return { mock };
     }
 


### PR DESCRIPTION
Rename `Calldata` lib to `CalldataSlice` to clarify the purpose
Implement `CalldataParse` lib allowing efficient packed value parse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new parsing utilities and a library rename with test-only call sites; no bounds checking in `CalldataParse` is intentional but callers must enforce offsets themselves.
> 
> **Overview**
> Introduces **`CalldataParse`**, a gas-oriented library for reading **left-aligned packed values** from `bytes calldata` via `at(shift)` → `CalldataWord` → `as*` helpers (addresses, `uint8`–`uint256`, `bytes1`–`bytes32`, and MSB-indexed `asBool`). **`at`** uses inline `calldataload` and **does not bounds-check**, as documented.
> 
> Renames the existing slicing library from **`Calldata`** to **`CalldataSlice`** (same `slice` APIs and behavior) and updates **`CalldataSliceMock`** / **`CalldataSlice.test.ts`** accordingly.
> 
> Adds **`CalldataParseMock`** and a Hardhat suite **`CalldataParse.test.ts`** covering byte offsets, bool bit extraction, addresses, and all supported `uintN` / `bytesN` widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da967e0fa0651877d1d3c757f0ef92c8fbf7892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->